### PR TITLE
Updated content for Apache NetBeans Events

### DIFF
--- a/netbeans.apache.org/src/content/community/events.asciidoc
+++ b/netbeans.apache.org/src/content/community/events.asciidoc
@@ -27,18 +27,16 @@
 
 == Apache NetBeans Events
 
-Users and developers either convoke or participate in different events and conferences. 
+For events held by Apache projects, clearance needs to be obtained. Clearance is granted by VP, Brand (Shane Curcuru) usually in response to an email to trademarks@apache.org with a description of what is being requested. This is a private email list. The request should reference any discussion that has happened on dev and private lists to give complete context. For a list of events such as the continually ongoing NetBeans Days (to be renamed to Apache NetBeans Days), a blanket request is fine assuming that the (P)PMC has been involved, i.e., the committers on the NetBeans Apache dev mailing list. A description of the events and the involvement of the (P)PMC is what VP, Brand will use to either approve or ask more questions. Casual get-togethers with no commercial sponsors are easier to get approval for, which is exactly what the Apache NetBeans Days are.
 
-The Apache Software Foundation makes sure that all organizations are treated
-fairly, making sure the project does not favor any commercial entities or
-organizations over others.
+Apache NetBeans Days are a class of events which happen regularly, with a clear definition of what makes an event be part of that class:
 
-In order to achieve those goals, the Apache NetBeans Project has to follow
-link:https://cwiki.apache.org/confluence/display/NETBEANS/NetBeans+Events[some
-guidelines] before announcing or promoting these events.
+1. Have its opening keynote focus on the current state and roadmap of NetBeans. 
+2. Have all demos done throughout the event in NetBeans.
+3. Must be discussed/notified via the Apache NetBeans dev mailing list.
+Note: From an Apache point of view what's important (besides trademarks being respected) is that all organizations are treated fairly and that it's clear that they cannot "own" the event or project. Making sure we don't favor commercial entities or organizations over others is a strong requirement of the ASF's 501c(3) status, so we're very picky about that. And besides this legal requirement, it's what makes the ASF a unique place where companies which might compete in the market can collaborate in a fair way, due to our very neutral status.
 
-We are still working out those requirements, this page will then list
-events of interest for the NetBeans Community.
+For publicizing NetBeans events, the Apache News posts at https://blogs.apache.org/foundation/ could mention those events, best is to contact press@apache.org for that. Apache has an Event Listing (https://events.apache.org/), that we'd also like to make use of.
 
 === Apache Software Foundation resources
 


### PR DESCRIPTION
Moving content from https://cwiki.apache.org/confluence/display/NETBEANS/NetBeans+Events to netbeans.apache.org, next step is to add list of upcoming events, locations, etc.