### PR TITLE
Download PGP signature and MD5 and SHA1 sums from a correct locations.

### DIFF
--- a/netbeans.apache.org/src/content/download/nb90/nb90-beta.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb90/nb90-beta.asciidoc
@@ -49,13 +49,13 @@ NOTE: It's mandatory to link against dist.apache.org for the sums & keys. https 
 Apache NetBeans 9.0 Beta is available for download from your closest Apache mirror. For this release no installers are provided, please just download the binaries and unzip them.
 
 - Source: link:https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-source.zip[incubating-netbeans-java-9.0-beta-source.zip] (
-link:https://dist.apache.org/repos/dist/dev/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-source.zip.asc[PGP ASC], 
-link:https://dist.apache.org/repos/dist/dev/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-source.zip.md5[MD5], 
-link:https://dist.apache.org/repos/dist/dev/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-source.zip.sha1[SHA-1])
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-source.zip.asc[PGP ASC], 
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-source.zip.md5[MD5], 
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-source.zip.sha1[SHA-1])
 - Binaries: link:https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-bin.zip[incubating-netbeans-java-9.0-beta-bin.zip] ( 
-link:https://dist.apache.org/repos/dist/dev/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-bin.zip.asc[PGP ASC],
-link:https://dist.apache.org/repos/dist/dev/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-bin.zip.md5[MD5],
-link:https://dist.apache.org/repos/dist/dev/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-bin.zip.sha1[SHA-1])
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-bin.zip.asc[PGP ASC],
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-bin.zip.md5[MD5],
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-bin.zip.sha1[SHA-1])
 
 ////
 NOTE: Using https below is highly recommended.


### PR DESCRIPTION
The "dev" space should only be used for staging releases for voting, not for general users. Moreover, "dist/dev/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta" is actually RC1, which was never released.