### PR TITLE
Update who.asciidoc - John as committer

### DIFF
--- a/netbeans.apache.org/src/content/community/who.asciidoc
+++ b/netbeans.apache.org/src/content/community/who.asciidoc
@@ -317,6 +317,8 @@ Committer
   - Java, Plugins, NetCAT 
 
 === John McDonnell
+Committer
+
   - BearingPoint Ireland, Dublin, Ireland 
   - Maven, Java EE, Docker 
 


### PR DESCRIPTION
Updating the who is who page, marking John as a committer (& testing jenkins job)