### PR TITLE
Removed whole <form> as statistics.nb.org will be down.

### DIFF
--- a/netbeans.apache.org/src/content/nb/issues.html
+++ b/netbeans.apache.org/src/content/nb/issues.html
@@ -16,11 +16,4 @@ type=raw
 <p>
     Thank you for helping us make Apache NetBeans better!
 </p>
-
-<form action="http://statistics.netbeans.org/analytics/upload.jsp" method="post">
-    <input name="view-data" value="&amp;View Data" alt="&amp;Hide data" type="hidden" align="left">
-    <input name="exit" value="Close" type="hidden">
-</form>
-
-
 </body></html>


### PR DESCRIPTION
The <form> element makes no sense as users will be asked to report every exception to JIRA manually.