### PR TITLE
Fixes the first link to the wiki index

### DIFF
--- a/netbeans.apache.org/src/content/help/index.asciidoc
+++ b/netbeans.apache.org/src/content/help/index.asciidoc
@@ -34,7 +34,7 @@ The following resources are available:
 
 - Visit the link:https://netbeans.org/kb/index.html[netbeans.org docs & support] section in the old website.
 - Our link:https://www.youtube.com/user/NetBeansVideos[YouTube Video Channel] contains many tutorials and tips.
-- The previous link:wiki/index.asciidoc[wiki] has been partially migrated and is being updated.
+- The previous link:/wiki/index.asciidoc[wiki] has been partially migrated and is being updated.
 - The link:https://github.com/apache/incubator-netbeans-website-cleanup[content of the previous netbeans.org website] is being cleaned up in github.
 - The link:https://github.com/apache/incubator-netbeans-website[current Apache NetBeans website] (i.e., this website) is also hosted at github.
 


### PR DESCRIPTION
It should be an absolute path. See https://netbeans.apache.org/help/index.html which sends you to the non-existing https://netbeans.apache.org/help/wiki/index.asciidoc