### PR TITLE
[NETBEANS-636] license link for whimsy

### DIFF
--- a/netbeans.apache.org/src/content/templates/footer.gsp
+++ b/netbeans.apache.org/src/content/templates/footer.gsp
@@ -101,7 +101,7 @@
 <div class='footer-disclaimer'>
     <div class="footer-disclaimer-content">
         <p>Copyright &copy; 2017-2018 <a href="https://www.apache.org">The Apache Software Foundation</a>.</p>
-        <p>Licensed under the Apache Software <a href="https://www.apache.org/licenses/">license</a>, version 2.0</p>
+        <p>Licensed under the Apache <a href="https://www.apache.org/licenses/">license</a>, version 2.0</p>
         <p><a href="https://incubator.apache.org/" alt="Apache Incubator"><img src='/images/incubator_feather_egg_logo_bw_crop.png' title='Apache Incubator'></img></a></p>
         <div style='max-width: 40em; margin: 0 auto'>
             <p>Apache NetBeans is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.</p>

--- a/netbeans.apache.org/src/content/templates/footer.gsp
+++ b/netbeans.apache.org/src/content/templates/footer.gsp
@@ -101,7 +101,7 @@
 <div class='footer-disclaimer'>
     <div class="footer-disclaimer-content">
         <p>Copyright &copy; 2017-2018 <a href="https://www.apache.org">The Apache Software Foundation</a>.</p>
-        <p>Licensed under the <a href="https://www.apache.org/licenses/">Apache Software License, version 2.0.</a></p>
+        <p>Licensed under the Apache Software <a href="https://www.apache.org/licenses/">license</a>, version 2.0</p>
         <p><a href="https://incubator.apache.org/" alt="Apache Incubator"><img src='/images/incubator_feather_egg_logo_bw_crop.png' title='Apache Incubator'></img></a></p>
         <div style='max-width: 40em; margin: 0 auto'>
             <p>Apache NetBeans is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.</p>


### PR DESCRIPTION
It seems the whimsy website tool at https://whimsy.apache.org/pods/project/netbeans requires _BOTH_ a link with text "license" and href "^https?://.*apache.org/licenses/$", let's do that.