### PR TITLE
Update Center redirection for NetCAT

### DIFF
--- a/netbeans.apache.org/src/content/.htaccess
+++ b/netbeans.apache.org/src/content/.htaccess
@@ -2,4 +2,4 @@ DirectoryIndex index.html index.asciidoc
 Redirect 302 /download/9.0-beta/source https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-source.zip
 Redirect 302 /download/9.0-beta/binary https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-bin.zip
 Redirect 301 /updates/8.2/uc/final/certified/catalog.xml.gz http://updates.netbeans.org/netbeans/updates/8.2/uc/final/certified/catalog.xml.gz
-Redirect 302 /nb/updates/9.0/ http://netbeans-vm.apache.org/uc/9.0/
+Redirect 302 /nb/updates/9.0/ http://builds.apache.org/view/Incubator%20Projects/job/incubator-netbeans-release/328/artifact/dist/nbms/


### PR DESCRIPTION
This PR will make
https://netbeans.apache.org/nb/updates/9.0/updates.xml.gz
redirect to
https://dist.apache.org/repos/dist/dev/incubator/netbeans/incubating-netbeans-java/incubating-9.0-vc2/nbms/updates.xml.gz
instead of the current
http://netbeans-vm.apache.org/uc/9.0/
which currently redirects to the Apache Mirror System.

With the following effects:
1. We will loss the stats tracking set up at netbeans-vm.apache.org
2. All 9.0 RC candidates UC will now change