### PR TITLE
NetBeans 9.0 Release Announcement

### DIFF
--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -38,7 +38,7 @@ for important requirements for download pages for Apache projects.
 === Apache NetBeans 9.0
 
 - link:nb90/[Apache NetBeans 9.0 Features]
-- link:nb90/nb90.html[Apache NetBeans 9.0], released on the XXX of July, 2018.
+- link:nb90/nb90.html[Apache NetBeans 9.0], released on the 1st of August, 2018.
 - link:nb90/nb90-rc1.html[Apache NetBeans 9.0 RC1], released on the 28th of May, 2018.
 - link:nb90/nb90-beta.html[Apache NetBeans 9.0 Beta], released on the 22nd of February, 2018.
 

--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -38,6 +38,7 @@ for important requirements for download pages for Apache projects.
 === Apache NetBeans 9.0
 
 - link:nb90/[Apache NetBeans 9.0 Features]
+- link:nb90/nb90.html[Apache NetBeans 9.0], released on the XXX of July, 2018.
 - link:nb90/nb90-rc1.html[Apache NetBeans 9.0 RC1], released on the 28th of May, 2018.
 - link:nb90/nb90-beta.html[Apache NetBeans 9.0 Beta], released on the 22nd of February, 2018.
 

--- a/netbeans.apache.org/src/content/download/nb90/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb90/index.asciidoc
@@ -38,6 +38,7 @@ The main goals for this release are
 
 === Downloads
 
+- See link:/download/nb90/nb90.html[Apache NetBeans 9.0], released in July 2018.
 - See link:/download/nb90/nb90-rc1.html[Apache NetBeans 9.0 RC1], released in May 2018.
 - See link:/download/nb90/nb90-beta.html[Apache NetBeans 9.0 Beta], released in February 2018.
 

--- a/netbeans.apache.org/src/content/download/nb90/nb90.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb90/nb90.asciidoc
@@ -34,7 +34,7 @@ for important requirements for download pages for Apache projects.
 
 == Apache NetBeans 9.0 Release
 
-Apache NetBeans (incubating) 9.0 RC1 announced on the XXth of July, 2018.
+Apache NetBeans (incubating) 9.0 announced on the 1st of August, 2018.
 
 === Main features
 
@@ -46,7 +46,7 @@ See link:/download/nb90/index.html[Apache NetBeans 9.0 Features] for a full list
 NOTE: It's mandatory to link to the source. It's optional to link to the binaries.
 NOTE: It's mandatory to link against dist.apache.org for the sums & keys. https is recommended.
 ////
-Apache NetBeans 9.0 RC1 is available for download from your closest Apache mirror. For this release no installers are provided, please just download the binaries and unzip them.
+Apache NetBeans 9.0 is available for download from your closest Apache mirror. For this release no installers are provided, please just download the binaries and unzip them.
 
 - Source: link:https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans-java/incubating-9.0-rc1/incubating-netbeans-java-9.0-source.zip[incubating-netbeans-java-9.0-source.zip] (
 link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-rc1/incubating-netbeans-java-9.0-source.zip.asc[PGP ASC], 

--- a/netbeans.apache.org/src/content/download/nb90/nb90.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb90/nb90.asciidoc
@@ -1,0 +1,79 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+////
+
+NOTE: 
+See https://www.apache.org/dev/release-download-pages.html 
+for important requirements for download pages for Apache projects.
+
+////
+= Apache NetBeans 9.0 / Apache NetBeans
+:jbake-type: page
+:jbake-tags: download
+:jbake-status: published
+:keywords: Apache NetBeans 9.0 download
+:description: Apache NetBeans 9.0 download page
+:toc: left
+:toc-title:
+
+== Apache NetBeans 9.0 Release
+
+Apache NetBeans (incubating) 9.0 RC1 announced on the XXth of July, 2018.
+
+=== Main features
+
+See link:/download/nb90/index.html[Apache NetBeans 9.0 Features] for a full list of features.
+
+=== Downloading
+
+////
+NOTE: It's mandatory to link to the source. It's optional to link to the binaries.
+NOTE: It's mandatory to link against dist.apache.org for the sums & keys. https is recommended.
+////
+Apache NetBeans 9.0 RC1 is available for download from your closest Apache mirror. For this release no installers are provided, please just download the binaries and unzip them.
+
+- Source: link:https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans-java/incubating-9.0-rc1/incubating-netbeans-java-9.0-source.zip[incubating-netbeans-java-9.0-source.zip] (
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-rc1/incubating-netbeans-java-9.0-source.zip.asc[PGP ASC], 
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-rc1/incubating-netbeans-java-9.0-source.zip.sha1[SHA-1])
+- Binaries: link:https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans-java/incubating-9.0-rc1/incubating-netbeans-java-9.0-bin.zip[incubating-netbeans-java-9.0-bin.zip] ( 
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-rc1/incubating-netbeans-java-9.0-bin.zip.asc[PGP ASC],
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-rc1/incubating-netbeans-java-9.0-bin.zip.sha1[SHA-1])
+
+////
+NOTE: Using https below is highly recommended.
+////
+It is essential that you link:https://www.apache.org/dyn/closer.cgi#verify[verify the integrity] of the downloaded files using the PGP signatures (.asc file) or a hash (.sha1 files).  The PGP keys used to sign this release are available link:https://dist.apache.org/repos/dist/release/incubator/netbeans/KEYS[here].
+
+=== Building from source
+
+The sources for this release have been tagged as link:https://github.com/apache/incubator-netbeans/tree/9.0-vc3[9.0-vc3] at github.  See the link:/download/index.html#source[instructions on how to build] this release yourself from the source code.
+
+=== Community approval
+
+As in any other Apache Project, the Apache NetBeans Community approved this release through the following voting processes in our link:/community/mailing-lists.html[mailing lists] :
+
+#- link:https://lists.apache.org/thread.html/c2a06adc83e2819e6d96c7dff8d0e22a97001f99bfda12515d4d9609@%3Cdev.netbeans.apache.org%3E[PPMC vote]
+#- link:https://lists.apache.org/thread.html/94f7a5e4601e26c7edb8264df7df53dd8ed215ecfc568816a162f2af@%3Cdev.netbeans.apache.org%3E[PPMC vote result]
+#- link:https://lists.apache.org/thread.html/13af566fb266308d0a91c3e860d22fb1766464df9fe94126d74084fb@%3Cgeneral.incubator.apache.org%3E[IPMC vote]
+#- link:https://lists.apache.org/thread.html/8f15a994bc613c7c0915063c6b8cfde7d584c425f8566cd93d20fe57@%3Cgeneral.incubator.apache.org%3E[IPMC vote result]
+#- link:https://lists.apache.org/thread.html/1eb3e248e4f4f980ee21d4d3d103ed7ce17020e62489ba4be89e0a9a@%3Cgeneral.incubator.apache.org%3E[IPMC announce]
+#
+=== Known issues
+
+Please visit link:https://cwiki.apache.org/confluence/display/NETBEANS/Apache+NetBeans+9.0[this confluence page] for a list of known issues.

--- a/netbeans.apache.org/src/content/templates/footer.gsp
+++ b/netbeans.apache.org/src/content/templates/footer.gsp
@@ -88,8 +88,9 @@
                 <ul>
                     <li><a href="/download/index.html#releases">Releases</a></li>
                     <ul>
-                        <li><a href="/download/nb90/nb90-beta.html">Apache NetBeans 9.0 (beta)</a></li>
+                        <li><a href="/download/nb90/nb90.html">Apache NetBeans 9.0</a></li>
                         <li><a href="/download/nb90/nb90-rc1.html">Apache NetBeans 9.0 (RC1)</a></li>
+                        <li><a href="/download/nb90/nb90-beta.html">Apache NetBeans 9.0 (beta)</a></li>
                     </ul>
                     <li><a href="/plugins/index.html">Plugins</a></li>
                     <li><a href="/download/index.html#source">Building from source</a></li>

--- a/netbeans.apache.org/src/content/templates/news.gsp
+++ b/netbeans.apache.org/src/content/templates/news.gsp
@@ -23,8 +23,8 @@
     <div class='grid-container'>
         <div class='cell'>
             <div class="annotation">Just released!</div>
-            <h1>Apache NetBeans 9.0 RC1</h1>
-            <p><a class="button success" href="/download/nb90/nb90-rc1.html">Read more</a></p>
+            <h1>Apache NetBeans 9.0</h1>
+            <p><a class="button success" href="/download/nb90/nb90.html">Read more</a></p>
         </div>
     </div>
 </section>

--- a/netbeans.apache.org/src/content/templates/slider.gsp
+++ b/netbeans.apache.org/src/content/templates/slider.gsp
@@ -45,11 +45,11 @@
               <div class='grid-container'>
                   <div class='cell'>
                       <div class='annotation'>Apache NetBeans Transition News</div>
-                      <h1>Apache NetBeans 9.0 RC1 Released!</h1>
+                      <h1>Apache NetBeans 9.0 Released!</h1>
                       <p>
-                        Download Apache NetBeans 9.0 RC1 from an Apache mirror near you.
+                        Download Apache NetBeans 9.RC1 from an Apache mirror near you.
                       </p>
-                      <p><a class='button success' href="/download/nb90/nb90-rc1.html">Download</a></p>
+                      <p><a class='button success' href="/download/nb90/nb90.html">Download</a></p>
                   </div>
               </div>
           </section>

--- a/netbeans.apache.org/src/content/templates/slider.gsp
+++ b/netbeans.apache.org/src/content/templates/slider.gsp
@@ -47,7 +47,7 @@
                       <div class='annotation'>Apache NetBeans Transition News</div>
                       <h1>Apache NetBeans 9.0 Released!</h1>
                       <p>
-                        Download Apache NetBeans 9.RC1 from an Apache mirror near you.
+                        Download Apache NetBeans 9.0 from an Apache mirror near you.
                       </p>
                       <p><a class='button success' href="/download/nb90/nb90.html">Download</a></p>
                   </div>


### PR DESCRIPTION
In preparation for the 9.0 Release. 
Still missing:
- Links to votes.
- Verify links to final artifacts.
- Setting the final release date.