### PR TITLE
Download section in release

### DIFF
--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -42,6 +42,35 @@ for important requirements for download pages for Apache projects.
 - link:nb90/nb90-rc1.html[Apache NetBeans 9.0 RC1], released on the 28th of May, 2018.
 - link:nb90/nb90-beta.html[Apache NetBeans 9.0 Beta], released on the 22nd of February, 2018.
 
+[[downloading]]
+=== Downloading
+
+////
+NOTE: It's mandatory to link to the source. It's optional to link to the binaries.
+NOTE: It's mandatory to link against dist.apache.org for the sums & keys. https is recommended.
+////
+Apache NetBeans 9.0 is available for download from your closest Apache mirror. For this release no official installers are provided, please just download the binaries and unzip them.
+
+- Source: link:https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans-java/incubating-9.0/incubating-netbeans-java-9.0-source.zip[incubating-netbeans-java-9.0-source.zip] (
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0/incubating-netbeans-java-9.0-source.zip.asc[PGP ASC],
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0/incubating-netbeans-java-9.0-source.zip.sha1[SHA-1])
+- Binaries: link:https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans-java/incubating-9.0/incubating-netbeans-java-9.0-bin.zip[incubating-netbeans-java-9.0-bin.zip] (
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0/incubating-netbeans-java-9.0-bin.zip.asc[PGP ASC],
+link:https://www.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0/incubating-netbeans-java-9.0-bin.zip.sha1[SHA-1])
+
+*Note:* Apache NetBeans community member Carl Mosca has made link:https://github.com/carljmosca/netbeans-macos-bundle[a Mac OSX installation bundle available here].
+
+Also see the following YouTube clips:
+
+link:https://www.youtube.com/watch?v=am-7aa2hYgc[Get Started with NetBeans from a ZIP Archive]
+
+link:https://www.youtube.com/watch?v=I8gdC7BBtbs[Get Started with NetBeans from a Mac OSX Installer]
+
+////
+NOTE: Using https below is highly recommended.
+////
+Officially, it is important that you link:https://www.apache.org/dyn/closer.cgi#verify[verify the integrity] of the downloaded files using the PGP signatures (.asc file) or a hash (.sha1 files).  The PGP keys used to sign this release are available link:https://dist.apache.org/repos/dist/release/incubator/netbeans/KEYS[here].
+
 [[latest]]
 == Latest Builds
 


### PR DESCRIPTION
As discussed in meeting, download urls are required when clicking the Download menu. So I added the download section as seen in [Apache NetBeans 9.0 Release](https://netbeans.apache.org/download/nb90/nb90.html) page to the [Download](https://netbeans.apache.org/download/index.html) page as well.