### PR TITLE
Remove markiewb from "who is who" page

### DIFF
--- a/netbeans.apache.org/src/content/community/who.asciidoc
+++ b/netbeans.apache.org/src/content/community/who.asciidoc
@@ -70,14 +70,6 @@ Committer, PPMC Member
   - Gradle, Java 
   -  https://github.com/kelemen 
 
-=== Benno Markiewicz 
-Committer, PPMC Member
-
-  - apache id: markiewb 
-  - Leipzig, Germany 
-  - Platform, Java editor, Maven, Hints 
-  - http://twitter.com/@benM4 https://benkiew.wordpress.com/ 
-
 === Bernd Ruehlicke
   - Eriksfiord, Inc.,  Houston, TX, USA 
   - Platform, Database, JavaFX, Ant 


### PR DESCRIPTION
I haven't been active for over one year in NB and have no time nor plans to do so