### PR TITLE
Hotfix: jbake fails with undefined method start_with?

### DIFF
--- a/netbeans.apache.org/gradle/deps.gradle
+++ b/netbeans.apache.org/gradle/deps.gradle
@@ -10,7 +10,7 @@ buildscript {
         }
         sharedDependencies = {
             classpath "org.codehaus.groovy:groovy-all:${libs.groovy}"
-            classpath "org.jbake:jbake-gradle-plugin:+"
+            classpath "org.jbake:jbake-gradle-plugin:1.2.0"
             classpath "io.freefair.gradle:jsass-gradle-plugin:0.6.0"
         }
         tomcatDependencies = {


### PR DESCRIPTION
Fixing the version of jbake-gradle-plugin, otherwise we get a

    Caused by: org.asciidoctor.internal.AsciidoctorCoreException: org.jruby.exceptions.RaiseException: (NoMethodError) asciidoctor: FAILED: <stdin>: Failed to load AsciiDoc document - undefined method `start_with?' for nil:NilClass
        at org.asciidoctor.internal.JRubyAsciidoctor.render(JRubyAsciidoctor.java:341)
        at org.asciidoctor.internal.JRubyAsciidoctor.render(JRubyAsciidoctor.java:448)
        at org.jbake.parser.AsciidoctorEngine.processAsciiDoc(AsciidoctorEngine.java:141)

`