### PR TITLE
Style "GitHub" with capitalization

### DIFF
--- a/bits.netbeans.org/README.asciidoc
+++ b/bits.netbeans.org/README.asciidoc
@@ -5,7 +5,7 @@ This directory will be responsible for building the bits.netbeans.org website.
 It currently has a `build.xml` file that builds the NetBeans javadoc and extracts it in the `javadoc` directory.
 
 == TODO:
-  - Improve the `build.xml` file to take into account github branches and NetBeans releases.
+  - Improve the `build.xml` file to take into account GitHub branches and NetBeans releases.
   - Build javadoc zip files?
   - Build other parts of http://bits.netbeans.org
   - Publish this somewhere (http://bits.apache.netbeans.org?)

--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -81,7 +81,7 @@ link:https://jenkins.io/index.html[Jenkins] is quite busy link:https://builds.ap
 
 You can of course build Apache NetBeans from source. To do so:
 
-. Clone the https://github.com/apache/incubator-netbeans github repository.
+. Clone the https://github.com/apache/incubator-netbeans GitHub repository.
 . Install Oracle's Java 8 or Open JDK v8.
 . Install Apache Ant 1.10 or greater (https://ant.apache.org/).
 
@@ -103,7 +103,7 @@ This is a list of Apache NetBeans (incubating) repositories:
 - https://github.com/apache/incubator-netbeans The main source code repository.
 - https://github.com/apache/incubator-netbeans-website This website's repository.
 - https://github.com/apache/incubator-netbeans-website-cleanup A repository used to clean up existing documentation from http://netbeans.org
-- Emilian Bold has converted the previous Mercurial repository (http://hg.netbeans.org) to git, for historical reference, and has kindly uploaded it to github at https://github.com/emilianbold/netbeans-releases. Thanks, Emilian!
+- Emilian Bold has converted the previous Mercurial repository (http://hg.netbeans.org) to git, for historical reference, and has kindly uploaded it to GitHub at https://github.com/emilianbold/netbeans-releases. Thanks, Emilian!
 
 [[previous]]
 == Previous NetBeans versions

--- a/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
+++ b/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
@@ -62,17 +62,17 @@ We appreciate new contributors to adhere to the following guidelines, to make th
 == Learn to run and debug NetBeans IDE or Platform applications
 link:/participate/build-run-debug-tutorials.html[Watch a series of 5 short videos] (2 minutes on average) showing how to build, run and debug the NetBeans IDE or any NetBeans platform application from sources. 
 
-== Contributing to Apache NetBeans in github
+== Contributing to Apache NetBeans in GitHub
 
 === Boostraping (do this once)
 
-Since you don't have write permissions to the github apache mirror, you need to
-fork https://github.com/apache/incubator-netbeans in github, this is done using
-the "fork" button on the top right of the github page.
+Since you don't have write permissions to the GitHub apache mirror, you need to
+fork https://github.com/apache/incubator-netbeans in GitHub, this is done using
+the "fork" button on the top right of the GitHub page.
 
 You then need to clone the forked repository in your computer.
 
-Finally, in your computer, you need to setup your name and email in github.
+Finally, in your computer, you need to setup your name and email in GitHub.
 This will also help git to rebase in order to fulfill its task.
 
 [source, shell]
@@ -100,12 +100,12 @@ Before you can start modifying or upgrading the NetBeans code in your repository
 
 You are now ready to start modifying the NetBeans code. Use `git commit` when appropriate. Note that the commit message related to JIRA issues must start with `[NETBEANS-<issue number>]`.
 
-- Use `git push -u origin mybranch` to create and push the `mybranch` branch in your github fork. 
+- Use `git push -u origin mybranch` to create and push the `mybranch` branch in your GitHub fork. 
 - Use `git push origin mybranch` afterwards.
 
 If you have submitted many different commits it's a good idea to squash them together. See link:#squash[squashing commits on pull requests] for help on this.
 
-Once your code is ready to review create a *pull request* using the github interface. See https://help.github.com/articles/creating-a-pull-request/ for help.
+Once your code is ready to review create a *pull request* using the GitHub interface. See https://help.github.com/articles/creating-a-pull-request/ for help.
 
 === Be patient
 


### PR DESCRIPTION
Currently, the name "GitHub" is styled as both "GitHub" and "github" in this web site. This PR changes it to be "GitHub" everywhere, for internal consistency, and to match the styling that GitHub itself uses.