### PR TITLE
Fix "ununsubscribe" typo in mailing list page

### DIFF
--- a/netbeans.apache.org/src/content/community/mailing-lists.asciidoc
+++ b/netbeans.apache.org/src/content/community/mailing-lists.asciidoc
@@ -48,7 +48,7 @@ Using prefix tags in the subject line, such as [ java ] or [ javascript ] is enc
 
 - Mailing list address: link:mailto:users@netbeans.incubator.apache.org[users@netbeans.incubator.apache.org]
 - To subscribe please send an email to: link:mailto:users-subscribe@netbeans.incubator.apache.org[users-subscribe@netbeans.incubator.apache.org]
-- To ununsubscribe please send an email to: link:mailto:users-unsubscribe@netbeans.incubator.apache.org[users-unsubscribe@netbeans.incubator.apache.org]
+- To unsubscribe please send an email to: link:mailto:users-unsubscribe@netbeans.incubator.apache.org[users-unsubscribe@netbeans.incubator.apache.org]
 - link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-users/[See the Apache mailing list archive]
 - +++ <a href="https://lists.apache.org/list.html?users@netbeans.apache.org">Pony mail archive</a> +++
 
@@ -61,7 +61,7 @@ via events and tutorials, etc.
 
 - Mailing list address: link:mailto:dev@netbeans.incubator.apache.org[dev@netbeans.incubator.apache.org]
 - To subscribe please send an email to: link:mailto:dev-subscribe@netbeans.incubator.apache.org[dev-subscribe@netbeans.incubator.apache.org]
-- To ununsubscribe please send an email to: link:mailto:dev-unsubscribe@netbeans.incubator.apache.org[dev-unsubscribe@netbeans.incubator.apache.org]
+- To unsubscribe please send an email to: link:mailto:dev-unsubscribe@netbeans.incubator.apache.org[dev-unsubscribe@netbeans.incubator.apache.org]
 - link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-dev/[See the Apache mailing list archive]
 - +++ <a href="https://lists.apache.org/list.html?dev@netbeans.apache.org">Pony mail archive</a> +++
 
@@ -72,7 +72,7 @@ Specifically for those involved in the NetBeans Community Acceptance Testing (Ne
 
 - Mailing list address: link:mailto:netcat@netbeans.incubator.apache.org[netcat@netbeans.incubator.apache.org]
 - To subscribe please send an email to: link:mailto:netcat-subscribe@netbeans.incubator.apache.org[netcat-subscribe@netbeans.incubator.apache.org]
-- To ununsubscribe please send an email to: link:mailto:netcat-unsubscribe@netbeans.incubator.apache.org[netcat-unsubscribe@netbeans.incubator.apache.org]
+- To unsubscribe please send an email to: link:mailto:netcat-unsubscribe@netbeans.incubator.apache.org[netcat-unsubscribe@netbeans.incubator.apache.org]
 - link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-netcat/[See the Apache mailing list archive]
 - +++ <a href="https://lists.apache.org/list.html?netcat@netbeans.apache.org">Pony mail archive</a> +++
 
@@ -86,7 +86,7 @@ are able to write to this mailing list.
 
 - Mailing list address: link:mailto:announce@netbeans.incubator.apache.org[announce@netbeans.incubator.apache.org]
 - To subscribe please send an email to: link:mailto:announce-subscribe@netbeans.incubator.apache.org[announce-subscribe@netbeans.incubator.apache.org]
-- To ununsubscribe please send an email to: link:mailto:announce-unsubscribe@netbeans.incubator.apache.org[announce-unsubscribe@netbeans.incubator.apache.org]
+- To unsubscribe please send an email to: link:mailto:announce-unsubscribe@netbeans.incubator.apache.org[announce-unsubscribe@netbeans.incubator.apache.org]
 - link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-announce/[See the Apache mailing list archive]
 
 [[commits]]
@@ -96,7 +96,7 @@ Receive GitHub commit messages whenever a commit is done.
 
 - Mailing list address: link:mailto:commits@netbeans.incubator.apache.org[commits@netbeans.incubator.apache.org]
 - To subscribe please send an email to: link:mailto:commits-subscribe@netbeans.incubator.apache.org[commits-subscribe@netbeans.incubator.apache.org]
-- To ununsubscribe please send an email to: link:mailto:commits-unsubscribe@netbeans.incubator.apache.org[commits-unsubscribe@netbeans.incubator.apache.org]
+- To unsubscribe please send an email to: link:mailto:commits-unsubscribe@netbeans.incubator.apache.org[commits-unsubscribe@netbeans.incubator.apache.org]
 - link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-commits/[See the Apache mailing list archive]
 - +++ <a href="https://lists.apache.org/list.html?commits@netbeans.apache.org">Pony mail archive</a> +++
 
@@ -107,7 +107,7 @@ Receive GitHub notifications whenever someone adds a comment to an issue and whe
 
 - Mailing list address: link:mailto:notifications@netbeans.incubator.apache.org[notifications@netbeans.incubator.apache.org]
 - To subscribe please send an email to: link:mailto:notifications-subscribe@netbeans.incubator.apache.org[notifications-subscribe@netbeans.incubator.apache.org]
-- To ununsubscribe please send an email to: link:mailto:notifications-unsubscribe@netbeans.incubator.apache.org[notifications-unsubscribe@netbeans.incubator.apache.org]
+- To unsubscribe please send an email to: link:mailto:notifications-unsubscribe@netbeans.incubator.apache.org[notifications-unsubscribe@netbeans.incubator.apache.org]
 - link:http://mail-archives.apache.org/mod_mbox/incubator-netbeans-notifications/[See the Apache mailing list archive]
 - +++ <a href="https://lists.apache.org/list.html?notifications@netbeans.apache.org">Pony mail archive</a> +++
 


### PR DESCRIPTION
This PR just fixes a typo in the Mailing Lists page.