### PR TITLE
SCSS improvements for tutorials

### DIFF
--- a/netbeans.apache.org/src/content/scss/common/_netbeans.scss
+++ b/netbeans.apache.org/src/content/scss/common/_netbeans.scss
@@ -180,7 +180,6 @@ section.hero {
 
 
 
-
 /*
     The toc for mobile is horizontal.
 */
@@ -189,12 +188,16 @@ section.hero {
   border-top: 1px solid #ddd;
   border-bottom: 1px solid #ddd;
   margin: 0 auto;
+  ul.sectlevel2, ul.sectlevel3, ul.sectlevel4 {
+    /* We hide sectlevels 2 and up in mobile */
+    display: none;
+  }
   ul {
     margin: 0;
     padding: 8px;
     list-style-type: none;
     li {
-      display: inline-block;
+      display: block;
       font-size: $font-size-small;
       color: $nb-color-mid-blue;
       a {
@@ -213,7 +216,14 @@ section.hero {
     border-bottom: 0px;
     border-left: 1px solid #ddd;
     max-width: 15em;
-    margin: 32px 0 2em 2em;
+    margin: 0 0 2em 2em;
+    float: right;
+
+    ul.sectlevel2, ul.sectlevel3, ul.sectlevel4 {
+      /* We show sectlevels 2 and up */
+      display: block;
+    }
+
     ul {
       margin-left: 8px;
       li {
@@ -229,6 +239,11 @@ section.hero {
   vertical-align: top;
 }
 
+table {
+  width: auto;
+  margin: 1rem auto;
+}
+
 table tbody tr {
   border-bottom: 1px solid #f1f1f1;
 }
@@ -239,11 +254,7 @@ table tbody tr:nth-child(2n) {
 }
 
 .main-content {
-  padding: 0;
-
-  .sect1 {
-    padding: 16px 32px;
-  }
+  padding: 0 16px;
 
   .aside {
     background-color: $nb-color-bg-blue;
@@ -260,89 +271,4 @@ table tbody tr:nth-child(2n) {
   box-shadow: none;
 }
 
-/*
-
-    main-content uses CSS Grid Layout (right now).
-    The idea is to have a main area and a sidebar, both responsive. 
-        The 'toc' generated with asciidoc (class 'toc') is positioned in the 'area-toc'.
-        We may add additional asides in the template.
-
-    Mobile:
-    [area-news]
-    [area-toc]
-    [area-tools]
-    [area-main]
-    [area-aside]
-
-    Desktop:
-
-    [area-news] [area-news]
-    [area-main] [area-toc]
-    [area-main] [area-aside]
-    [area-tools] [area-tools]
-
-    "news" content is provided in templates/news.gsp
-    "tools" content is provided in templates/tools.gsp
-    "aside" content is currently empty
-
-    Foundations medium media query is (https://foundation.zurb.com/sites/docs/media-queries.html)
-    @media screen and (min-width: 40em) {}
-
-*/
-
-.main-content {
-}
-
-/*@media screen and (min-width: 40em) {*/
-@include breakpoint(medium) {
-    .main-content .toc {
-        float: right;
-    }
-}
-
-
-/*.main-content {
-  display: grid;
-  grid-gap: 8px;
-  grid-template-areas: 
-    "area-news"
-    "area-toc"
-    "area-tools"
-    "area-main"
-    ;
-
-  .content {
-    grid-area: area-main;
-  }
-
-  .aside {
-    grid-area: area-news;
-  }
-
-  .tools {
-    grid-area: area-tools;
-  }
-
-  .toc {
-    grid-area: area-toc;
-  }
-}
-
-.toc {
-  grid-area: area-toc;
-}
-
-@media screen and (min-width: 40em) {
-
-  .main-content {
-    grid-template-columns: 3fr 1fr;
-    grid-template-rows: auto auto auto auto;
-    grid-template-areas:
-      "area-news area-news"
-      "area-main area-toc"
-      "area-main area-aside"
-      "area-tools area-tools"
-      ;
-  }
-}*/
 


### PR DESCRIPTION
Some SCSS improvements:
- Tables are no longer width:100%.
- We hide sect2 and up for TOC in mobile.
- Improved padding of main content.
These make the tutorials to look better (see for instance http://netbeans.apache.org/kb/docs/ide/git.html)