### PR TITLE
Tutorials use level 0 header

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect.asciidoc
@@ -29,13 +29,11 @@
 :description: Static Code Analysis in the NetBeans IDE Java Editor - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, Static Code Analysis in the NetBeans IDE Java Editor
 
-== Static Code Analysis in the NetBeans IDE Java Editor
-
 The NetBeans IDE Java Editor has a static code analysis feature, which is a tool for finding potential problems and detecting inconsistencies in your source code.
 
 In this tutorial, you will learn how to perform static analysis of your Java code using FindBugs and NetBeans Java Hints without actually running your applications.
 
-=== Requirements
+== Requirements
 
 *To complete this tutorial, you need the following software and resources.*
 
@@ -56,7 +54,7 @@ If using another NetBeans project, link:http://repo1.maven.org/maven2/com/google
 
 image::images/jar.png[]
 
-=== Setting Up the Tutorial Environment
+== Setting Up the Tutorial Environment
 
 In addition to the required software listed above you should have the following installed on your computer:
 
@@ -80,7 +78,7 @@ image::images/plugin-small.png[role="left", link="images/plugin.png"]
 4. Review the license agreement, select the license agreement option, and click Install.
 5. When the installation is complete, click Finish.
 
-=== Using Predefined Configurations
+== Using Predefined Configurations
 
 You can use the following predefined configurations when inspecting your code in the NetBeans IDE:
 
@@ -89,7 +87,7 @@ You can use the following predefined configurations when inspecting your code in
 * <<fb,FindBugs>>
 * <<default,Default>>
 
-==== Running All Analyzers
+=== Running All Analyzers
 
 The  ``All Analyzers``  configuration deploys all static code analysis tools available in the IDE.
 
@@ -128,7 +126,7 @@ NOTE: If you want to leave some part of your code that is reported as problemati
 image::images/suppress-small.png[role="left", link="images/suppress.png"]
 --
 
-==== Verifying Java Code against NetBeans Java Hints
+=== Verifying Java Code against NetBeans Java Hints
 
 The  ``NetBeans Java Hints``  configuration available in the IDE enables you to verify if the predefined coding standard rules are satisfied by the source code under consideration. In other words, it applies a set of NetBeans Java Hints (also known as code inspections) to your Java source files.
 
@@ -170,7 +168,7 @@ The following table displays the commands available in the Inspector Window.
 *Categorize* |Toggles the collapsed view of the problems detected in a file, project, or package or the categorized view of all the detected problems. 
 |===
 
-==== Finding Potential Problems in Java Code with FindBugs
+=== Finding Potential Problems in Java Code with FindBugs
 
 The  ``FindBugs``  configuration available in the IDE enables you to find a wide range of potential problems in your code. It invokes the popular open source FindBugs tool for code analysis in Java. The bug report gets generated and is displayed in the Inspector Window of the NetBeans IDE, which categorizes all the found problems and allows direct navigation from the bugs in the report to the suspicious code. You can also read a bug description in the adjacent window or review it at the link:http://findbugs.sourceforge.net/bugDescriptions.html[+FindBugs Bug Descriptions+] page by the pointer provided at the top of the left frame.
 
@@ -233,7 +231,7 @@ If you now press Alt-Enter in the source code where a bug is reported and click 
 image::images/fbenabled-small.png[role="left", link="images/fbenabled.png"]
 --
 
-==== Customizing a Default Configuration
+=== Customizing a Default Configuration
 
 While working on your code you may need to customize a predefined configuration that includes your own NetBeans Java hints or FindBugs bugs.
 
@@ -257,7 +255,7 @@ image::images/select-inspections-small.png[role="left", link="images/select-insp
 
 7. Click OK to save your  ``Default``  configuration.
 
-=== Creating and Deleting Configurations
+== Creating and Deleting Configurations
 
 You can create and delete your own configurations to be used in the static analysis of your Java code.
 
@@ -305,7 +303,7 @@ The  ``renamedConfig``  configuration is deleted from the Configurations list.
 
 NOTE: Refer to the link:http://platform.netbeans.org/tutorials/nbm-java-hint.html[+NetBeans Java Hint Module Tutorial+] for information on how to create a NetBeans module that provides one or more NetBeans Java hints.
 
-=== Running Single Inspections
+== Running Single Inspections
 
 You can inspect your code for a particular deficiency in your source code using the static code analysis feature in the NetBeans IDE.
 
@@ -331,7 +329,7 @@ image::images/hint-inspection-small.png[role="left", link="images/hint-inspectio
 4. In the Inspect dialog box, click Inspect to perform the source code analysis. 
 After the Inspect operation is completed, the hints that can be applied to your code or bugs that have been found are displayed in the Inspector Window below the Source Editor.
 
-=== Summary
+== Summary
 
 This tutorial covers most frequent usages of the static code analysis feature in the NetBeans IDE. Please note that with the static code analysis functionality you can also perform custom refactorings at a project scope, or apply particular refactoring configurations to several projects open in the IDE, etc.
 

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded.asciidoc
@@ -29,8 +29,6 @@
 :description: Debugging Multi-threaded Applications in NetBeans IDE - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, Debugging Multi-threaded Applications in NetBeans IDE
 
-== Debugging Multi-threaded Applications in NetBeans IDE
-
 This document describes how to use the Debugging window in NetBeans IDE to debug multi-threaded applications. The tutorial also demonstrate how to use the IDE to detect deadlocks in an application.
 
 The Debugging window simplifies the debugging process by integrating into one window the information about debugging sessions, application threads and thread call stacks. The Debugging window enables you to easily see the status of application threads and suspend and resume any of the threads in the session.
@@ -39,7 +37,7 @@ This tutorial uses two sample projects to demonstrate how to work with the Debug
 
 NOTE: To follow this tutorial, you need the  link:https://netbeans.org/projects/samples/downloads/download/Samples/Java/debugging-samples.zip[+Gallery Project and Deadlock Project+].
 
-=== Downloading the Sample Projects
+== Downloading the Sample Projects
 
 You can download the sample projects used in this tutorial in the following ways.
 
@@ -60,11 +58,11 @@ When you click Finish, the IDE initializes the local folder as a Subversion repo
 
 *Note.* For more about checking out sources with Subversion, see the section on link:../ide/subversion.html#settingUp[+Setting up Subversion+] in the link:../ide/subversion.html[+Guide to Subversion in NetBeans IDE+].
 
-=== Opening the Projects
+== Opening the Projects
 
 In this tutorial you will use two applications to demonstrate the IDE's support for debugging multi-threaded applications. In this exercise you will open and then run the two projects in the IDE. After you run the projects you will then proceed to debug each of the projects.
 
-==== Running the Gallery Project
+=== Running the Gallery Project
 
 The Gallery application is a simple Java Swing application that plays animated images. The application has two buttons that enable you to add and remove animated images. In this exercise you run the Gallery application.
 
@@ -81,7 +79,7 @@ image::images/debugging-gallery-app.png[title="Gallery application"]
 
 The Gallery project is a simple multi-threaded application that you will debug in this tutorial.
 
-==== Running the Deadlock Project
+=== Running the Deadlock Project
 
 The Deadlock application contains a  ``main``  method that starts a thread that runs for 500000 milliseconds. The  ``main``  method starts two threads that print to the Output window when they finish.
 
@@ -116,11 +114,11 @@ Main thread finished
 
 The Deadlock project is a simple Java application with two threads. When you debug the application you will create a deadlock to illustrate how the IDE can help you detect deadlocks.
 
-=== Debugging the Sample Projects
+== Debugging the Sample Projects
 
 The Gallery project is a simple Java Swing application that displays animated images. You add and remove the images by clicking buttons in the application. Clicking the 'More' button starts a new thread that displays and animates an image. Clicking the 'Less' button stops the most recent thread, stopping the animation and removing the image.
 
-==== Suspending Threads
+=== Suspending Threads
 
 In this exercise you start debugging the Gallery application and add some images to start some application threads. When you start a debugging session the IDE opens the Debugging window in the left pane of the IDE. The Debugging window displays a list of the threads in the session.
 
@@ -145,7 +143,7 @@ The Debugging window enables you to quickly view and change the status of thread
 
 image::images/debugging-window-toolbar.png[title="Debugging window toolbar"] 
 
-==== Switching Threads
+=== Switching Threads
 
 This exercise demonstrates what happens when you are stepping through an application and a different application thread hits a breakpoint. In this exercise you will set a method breakpoint and start stepping through the application. While you are stepping through the application you will start a new thread that will also hit the breakpoint. The IDE informs you when this occurs by displaying a notification in the Debugging window. You will then switch between threads.
 
@@ -195,7 +193,7 @@ The Debugging window enables you to very precisely view and control thread state
 
 You can quit the Gallery application. In the next exercise you will debug the Deadlock application and use the IDE to help you detect a deadlock.
 
-==== Detecting Deadlocks
+=== Detecting Deadlocks
 
 The IDE can help you identify potential deadlock situations by automatically searching for deadlocks among all suspended threads. When a deadlock is detected, the IDE displays a notification in the Debugging window and identifies the involved threads.
 

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-visual.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-visual.asciidoc
@@ -28,13 +28,11 @@
 :description: Using the Visual Debugger in NetBeans IDE - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, Using the Visual Debugger in NetBeans IDE
 
-== Using the Visual Debugger in NetBeans IDE
-
 This document describes how to use the Visual Debugger to help you locate and debug the code for visual elements in your GUI application. You can use the visual debugger in Java and JavaFX GUI applications.
 
 In this document you will use the Visual Debugger to explore the Anagram Game sample project. This document will demonstrate how to take a GUI snapshot of the application and then work with the snapshot to locate source code, add listeners to events and view the event log of GUI components.
 
-=== Taking a GUI Snapshot
+== Taking a GUI Snapshot
 
 In this tutorial you will use the Anagram Game sample application, a Java desktop application with a simple GUI that is available as a sample in the New Project wizard. After you create the project you will start a debugging session and take a GUI snapshot of the application.
 
@@ -63,11 +61,11 @@ image::images/debug-fullscreen.png[role="left", link="images/debug-fullscreen.pn
 
 In this guide to the visual debugger you will not use the Debugging window.
 
-=== Working with the Visual Debugger
+== Working with the Visual Debugger
 
 The GUI snapshot is a visual debugging tool that can help you locate the source code for GUI components. The source code for GUI components can sometimes be difficult to locate and the snapshot provides a way for you to locate the code based on the GUI instead of searching through the code. You can select components in the snapshot and invoke tasks from the popup menu to view the source code for the component, show the listeners and set breakpoints on components.
 
-==== Locating the Source Code for Components
+=== Locating the Source Code for Components
 
 This exercise will demonstrate how to use the GUI snapshot to navigate to the lines in the source code where a component is declared and defined. When you select a component in the GUI snapshot, you can use the popup menu to invoke various commands.
 
@@ -112,7 +110,7 @@ The IDE will open the source code in the editor at the line where the component 
 
 image::images/debug-hierarchy.png[title="Line of source code where component is added to container"]
 
-==== Exploring Component Events
+=== Exploring Component Events
 
 This exercise will demonstrate how you can use the GUI snapshot and the Events window to explore component events, enabling you to locate component listeners and the events that are triggered by the components.
 

--- a/netbeans.apache.org/src/content/kb/docs/java/editor-codereference.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-codereference.asciidoc
@@ -30,15 +30,14 @@
 :description:  Code Assistance in the NetBeans IDE Java Editor: A Reference Guide - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials,  Code Assistance in the NetBeans IDE Java Editor: A Reference Guide
 
-== Code Assistance in the NetBeans IDE Java Editor: A Reference Guide
 
 The purpose of any integrated development environment (IDE) is to maximize productivity and support seamless development from a single tool. This reference document describes useful code assistance features, customization options, and navigation capabilities of the NetBeans IDE's Java Editor.
 
-=== Smart Code Completion
+== Smart Code Completion
 
 The NetBeans IDE's Java Editor helps you quickly complete and generate code through the "smart" code completion feature. In a general sense, code completion is very useful when you want to fill in the missing code, look at the options available in the context of your application, and generate blocks of code when needed. See below for examples of how to use code completion.
 
-==== Invoking Code Completion
+=== Invoking Code Completion
 
 
 [.feature]
@@ -67,7 +66,7 @@ image::images/codecompletion4.png[role="right"]
 The first time  ``Ctrl-Space``  is pressed, only items matching the type, in this example an  ``int`` , are shown. Press  ``Ctrl-Space``  a second time, that is, press  ``Ctrl-Space``  twice, and _all_ the available items are shown, regardless of whether they match the provided type, as shown in the example on the left.
 
 
-==== Smart Suggestions at the Top
+=== Smart Suggestions at the Top
 
 [.feature]
 --
@@ -81,7 +80,7 @@ In the example on the left, the editor suggests inserting the  ``LinkedHashMap``
 If the "smart" suggestions are not the ones you want to use, press  ``Ctrl-Space``  again to see the complete list, as shown above.
 
  
-==== Camel Case Completion
+=== Camel Case Completion
 
 [.feature]
 --
@@ -93,7 +92,7 @@ Instead of typing consecutive characters, and then calling code completion, you 
 For example, type  ``IE`` , press  ``Ctrl-Space`` , and you will see a list of suggestions that match via camel case completion using the letter  ``I``  and then the letter  ``E`` .
 
  
-==== Completing Keywords
+=== Completing Keywords
 
 [.feature]
 --
@@ -105,7 +104,7 @@ Use code completion ( ``Ctrl-Space)``  to complete keywords in your code. The ed
 In the example on the left, the  ``ColorChooser``  class needs to extend the  ``JPanel``  class. You can quickly add the keyword  ``extends``  from the suggested items.
 
 
-==== Suggesting Names for Variable and Fields
+=== Suggesting Names for Variable and Fields
 
 [.feature]
 --
@@ -117,7 +116,7 @@ When you are adding a new field or a variable, use code completion ( ``Ctrl-Spac
 Type a prefix for the new name, press  ``Ctrl-Space``  and select the name you want to use from the list of suggestions.
 
  
-==== Suggesting Parameters
+=== Suggesting Parameters
 
 [.feature]
 --
@@ -131,7 +130,7 @@ For example, when you select a method from the code completion window which has 
 You can invoke the tooltips with method parameters by pressing  ``Ctrl-P``  (or Source > Show Method Parameters) at any time.
 
  
-==== Common Prefix Completion
+=== Common Prefix Completion
 
 [.feature]
 --
@@ -145,7 +144,7 @@ To check out how this feature works, try typing the following:
 1. Type  ``System.out.p``  and wait for code completion to show all fields and methods that start with "p." All the suggestions will be related to "print."
 2. Press the  ``Tab``  key and the editor automatically fills in the "print". You can continue and type "l" and, after pressing Tab, the "println" will be added.
  
-==== Subword Completion
+=== Subword Completion
 
 image::images/subcompletion.png[]
 
@@ -155,14 +154,14 @@ Sometimes you may not remember how an items starts, making it difficult to use c
 2. Check the Subword completion checkbox in the Editor | Code Completion tab in the Options window.
 3. Type part of the method you want to call,  ``prop``  as shown here, and then call up code completion. Relevant subwords, all applicable to properties on the object, in this example, are displayed.
  
-==== Chain Completion
+=== Chain Completion
 
 image::images/chain.png[]
 
 When you need to type a chain of commands, use smart code completion, that is, press  ``Ctrl-Space``  twice, and available chains will be shown. The editor scans variables, fields, and methods, that are visible from the context, and it will then suggest a chain that satisfies the expected type.
 
  
-==== Completion of Static Imports
+=== Completion of Static Imports
 
 image::images/static.png[] 
 
@@ -171,7 +170,7 @@ When you need to complete a statement while needing to make use of a static impo
 If you would like static import statements to be added automatically when you complete static statements as described above, go to Tools > Options > Editor > Formatting, select Java from the Language drop-down and Imports from the Category drop-down. Check the Prefer Static Imports checkbox.
 
  
-==== Excluding Items from Completion
+=== Excluding Items from Completion
 
 [.feature]
 --
@@ -188,7 +187,7 @@ image:images/exclude.png[role="left"]
 Either when "Configure excludes" is selected in code completion or when you go to Tools > Options > Editor > Code Completion, you can modify the exclusion rules you have defined.
 
  
-==== JPA Completion
+=== JPA Completion
 
 image::images/jpacompletion.png[]
 
@@ -197,7 +196,7 @@ When you are using the Java Persistence Annotation specification (JPA), you can 
  
 In the code completion window, icons are used to distinguish different members of the Java language. See <<appendixa,Appendix A>> at the end of this document to see the meanings of these icons.
 
-=== Managing Imports
+== Managing Imports
 
 There are several ways of how you can work with import statements. The IDE's Java Editor constantly checks your code for the correct use of import statements and immediately warns you when non-imported classes or unused import statements are detected.
 
@@ -244,12 +243,12 @@ Select Java from the Language drop-down.
 Check the Remove Unused Imports checkbox.
 
  
-=== Generating Code
+== Generating Code
 
 When working in the Java Editor, you can generate pieces of code in one of the two ways: by using code completion or from the Code Generation dialog box. Let's take a closer look at simple examples of automatic code generation.
 
 
-==== Using the Code Generation Dialog Box
+=== Using the Code Generation Dialog Box
 
 image::images/codegeneration1.png[]
 
@@ -261,7 +260,7 @@ In the example on the left, we are going to generate a constructor for the  ``Co
 In the IDE's Java Editor, you can automatically generate various constructs and whole methods, override and delegate methods, add properties and more.
 
  
-==== Using Code Completion
+=== Using Code Completion
 
 image::images/codegeneration2.png[]
 
@@ -272,12 +271,12 @@ Press Ctrl-Space to open the code completion window and choose the following ite
 In the code completion window, the constructors that can be automatically generated are marked with the image:images/newconstructor.png[] icon and the " ``generate`` " note. For more explanations of the icons and their meanings, see <<appendixa,Appendix A>>.
 
  
-=== Code Templates
+== Code Templates
 
 A Code Template is a predefined piece of code that has an abbreviation associated with it. See the examples below that show how you can use code templates.
 
 
-==== Using Code Templates
+=== Using Code Templates
 
 image::images/livetemplate.png[]
 
@@ -291,7 +290,7 @@ You can do one of the following:
 In the expanded template, editable parts are displayed as blue boxes. Use the  ``Tab``  key to go through the parts that you need to edit.
 
  
-==== Adding or Editing Code Templates
+=== Adding or Editing Code Templates
 
 [.feature]
 --
@@ -311,12 +310,12 @@ See link:http://wiki.netbeans.org/Java_EditorUsersGuide#How_to_use_Code_Template
 See also link:../php/code-templates.html[+Code Templates in NetBeans IDE for PHP+].
 
  
-=== Working with Javadoc
+== Working with Javadoc
 
 Use the following features that facilitate working with Javadoc for your code.
 
 
-==== Displaying Javadoc
+=== Displaying Javadoc
 
 image::images/javadoc.png[]
 
@@ -324,7 +323,7 @@ Place the cursor on an element and press  ``Ctrl-Shift-Space (or choose Source >
 
 In the IDE's main menu, click Window > IDE Tools > Javadoc Documentation to open the Javadoc window, in which the documentation is refreshed automatically for the location of your cursor.
 
-==== Creating Javadoc Stubs
+=== Creating Javadoc Stubs
 
 image::images/javadoc1.png[] 
 
@@ -332,7 +331,7 @@ Place the cursor above a method or a class that has no Javadoc, type  ``"/**`` "
 
 The IDE creates a skeletal structure for a Javadoc comment filled with some content. If you have a Javadoc window open, you will see the changes immediately while you are typing.
 
-==== Using Javadoc Hints
+=== Using Javadoc Hints
 
 image::images/javadoc2.png[] 
 
@@ -343,7 +342,7 @@ Click the bulb icon on the lefthand margin of the editor to fix Javadoc errors.
 If you do not want to see the hints related to Javadoc, choose Tools > Options > Editor > Hints, and clear the Javadoc checkbox in the list of hints that are displayed.
 
  
-==== Using Code Completion for Javadoc Tags
+=== Using Code Completion for Javadoc Tags
 
 image::images/javadoc3.png[]
 
@@ -352,7 +351,7 @@ Code completion is available for Javadoc tags.
 Type the "@" symbol and wait until the code completion window opens (depending on your settings, you may need to press  ``Ctrl-Space`` ).
 
  
-==== Generating Javadoc
+=== Generating Javadoc
 
 image::images/generate.png[]
 
@@ -363,7 +362,7 @@ In the example on the left, you can see a sample output of the Generate Javadoc 
 To customize Javadoc formatting options, right-click the project, choose Properties and open the Documenting panel under the Build category (available on Java projects only). For information about the options on this panel, click the Help button in this window.
 
  
-==== Analyzing Javadoc
+=== Analyzing Javadoc
 
 image::images/analyze-javadoc.png[]
 
@@ -375,11 +374,11 @@ To analyze and fix Javadoc comments:
 2. Select one or several checkboxes where you would like to fix Javadoc and click the Fix Selected button. 
 3. Click Go Over Fixed Problems and use the Up and Down arrows to actually add your comments. This might be helpful if you selected to fix several instances at once and now want to revisit the stubs.
  
-=== Using Hints
+== Using Hints
 
 While you are typing, the Java Editor checks your code and provides suggestions of how you can fix errors and navigate through code. The examples below show the types of hints that are available in the Editor and how to customize them.
 
-==== Using Hints to Fix Code
+=== Using Hints to Fix Code
 
 image::images/quickfixes.png[]
 
@@ -389,7 +388,7 @@ Hints are displayed automatically by default. However, if you want to view all h
 
 For example, try typing "myBoolean=true". The editor detects that this variable is not defined. Click the hint icon and see that the Editor suggests that you create a field, a method parameter, or a local variable. Select
 
-==== Customizing Hints
+=== Customizing Hints
 
 [.feature]
 --
@@ -411,7 +410,7 @@ To improve IDE's performance, you can do one of the following:
 * Limit the scope of dependency scans to the Source Root (search for dependencies only in the source root where the modified class is located) or current Project.
 * Disable dependency scanning (choose Project Properties > Build > Compiling and deselect the Track Java Dependencies option). In this case, the IDE does not scan for dependencies or updates the error badges when you modify a file.
  
-==== Surround With...
+=== Surround With...
 
 image::images/surroundwith.png[]
 
@@ -420,10 +419,10 @@ You can easily surround pieces of your code with various statements, such as  ``
 Select a block in your code that you want to surround with a statement and click the bulb icon in the lefthand margin (or press Alt-Enter). The editor displays a list of suggestions from which you select the statement you need.
 
 
-=== General Editor Features
+== General Editor Features
 
 
-==== Code Formatting
+=== Code Formatting
 
 [.feature]
 --
@@ -439,7 +438,7 @@ To customize the formatting settings for Java code:
 3. From the Category drop-down list, select the category that you would like to customize. For example, you can customize the number of blank lines, the size of tabs and indentation, wrapping style, etc.
 4. Modify the rules for the selected category and preview the result.
  
-==== Inserting and Highlighting Braces, Brackets, and Quotes
+=== Inserting and Highlighting Braces, Brackets, and Quotes
 
 image::images/braces.png[]
 
@@ -454,7 +453,7 @@ The editor also highlights matching pairs of braces, brackets and quotes. For ex
 
 To customize the highlight colors, choose Tools > Options > Editor > Highlighting.
 
-==== Code Folding
+=== Code Folding
 
 image::images/code-folded2.png[]
 
@@ -472,7 +471,7 @@ To customize the code folding options:
 2. To disable code folding, clear Enable Code Folding. Note that code folding is enabled by default.
 3. Select the blocks of code to be collapsed by default when you open a file.
  
-==== Customizing Keyboard Shortcuts
+=== Customizing Keyboard Shortcuts
 
 [.feature]
 --
@@ -496,11 +495,11 @@ If you want to add special characters, such as  ``Tab`` ,  ``Escape`` , or  ``En
 
 To find a shortcut for a specific command, type the command name in the Search field. To find a command by a combination, insert the cursor in the Search in Shortcuts field and press the shortcut key combination.
 
-=== Semantic Coloring and Highlighting
+== Semantic Coloring and Highlighting
 
 The IDE's Java Editor shows code elements in distinct colors, based on the semantics of your code. With semantic coloring, it becomes easier for you to identify various elements in your code. In addition to coloring, the Java Editor highlights similar elements with a particular background color. Thus, you can think of the highlighting feature as an alternative to the Search command, because in combination with error stripes, it gives you a quick overview of where the highlighted places are located within a file.
 
-==== Customizing Colors
+=== Customizing Colors
 
 [.feature]
 --
@@ -534,7 +533,7 @@ To import the IDE settings:
 3. Select the settings that you want to import and click OK.
 
 
-==== Coloring Example
+=== Coloring Example
 
 image::images/coloring.png[]
 
@@ -546,7 +545,7 @@ References to deprecated methods or classes are shown as strikethrough. This war
 
 Unused members are underlined with a gray wavy line. Comments are displayed in gray.
 
-==== Using Highlights
+=== Using Highlights
 
 image::images/highlightelement.png[]
 
@@ -556,19 +555,19 @@ If you place the cursor in an element, such as a field or a variable, all usages
 
 If you decide to rename all the highlighted instances, use the Instant Rename command (Ctrl-R or choose Refactor > Rename).
 
-=== Navigation
+== Navigation
 
 The Java Editor provides numerous ways of how you can navigate through code. See below for several examples that show the navigation features of the Java Editor.
 
 
-==== Error Stripes
+=== Error Stripes
 
 Error stripes in the righthand margin of the editor provide a quick overview of all marked places in the current file: errors, warnings, hints, highlighted occurrences, and annotations. Note that the error stripe margin represents an entire file, not just the part that is currently displayed in the editor. By using error stripes, you can immediately identify whether your file has any errors or warnings, without scrolling through the file.
 
 Click an error stripe to jump to the line that the mark refers to.
 
 
-==== Navigating From the Editor: Go To...
+=== Navigating From the Editor: Go To...
 
 image::images/gotodeclaration.png[]
 
@@ -586,14 +585,14 @@ image::images/gotoline.png[]
 * *Go To Line (Ctrl-G)*. Enter the line number to which you want to jump.
 * *Go To Bookmark (Ctrl-G Ctrl-G)*. Enables you to jump to a bookmark based on a key assigned to it in the Bookmarks window. (See the <<bookmarks,Bookmarks>> section for details.)
  
-==== Jumping to Last Edit
+=== Jumping to Last Edit
 
 image::images/jumplastedit.png[]
 
 To quickly return to your last edit, even if it is in another file or project, press Ctrl-Q or use the button in the top left corner of the Java Editor toolbar. The last edited document opens, and the cursor is at the position, which you edited last.
 
  
-==== Using Breadcrumbs
+=== Using Breadcrumbs
 
 image::images/breadcrumbs.png[]
 
@@ -606,7 +605,7 @@ Show/hide breadcrumbs from View | Show Breadcrumbs.
 Click on an arrow associated with a breadcrumb to see all available class members and select to jump to them.
 
  
-==== Switching Between Files
+=== Switching Between Files
 
 image::images/jumprecentfile.png[]
 
@@ -625,7 +624,7 @@ image::images/shift-f4.png[]
 
 * *Show Open Documents (Shift-F4)*. After you press Shift-F4, all open files are shown in the Documents window. Order the files based on your needs and choose the file you would like to open.
  
-==== Using Bookmarks
+=== Using Bookmarks
 
 image::images/bookmark.png[]
 
@@ -658,7 +657,7 @@ Two views are provided for viewing bookmarks and you can view the related code i
 In the Table view, you can assign keys to bookmarks so that when  ``Ctrl-G``  is pressed twice, you can quickly jump to a bookmark in your code.
 
  
-==== Using the Navigator
+=== Using the Navigator
 
 image::images/navigatorwindow.png[]
 
@@ -682,7 +681,7 @@ Matching items are highlighted.
 
 You can move to matching items by pressing the Up and Down arrow keys.
 
-=== Appendix A: Icons in the Code Completion Window
+== Appendix A: Icons in the Code Completion Window
 
 [cols="1,3,1,3"]
 |===

--- a/netbeans.apache.org/src/content/kb/docs/java/editor-inspect-transform.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-inspect-transform.asciidoc
@@ -29,20 +29,18 @@
 :description: Refactoring with Inspect and Transform in the NetBeans IDE Java Editor - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, Refactoring with Inspect and Transform in the NetBeans IDE Java Editor
 
-== Refactoring with Inspect and Transform in the NetBeans IDE Java Editor
-
 The NetBeans IDE Java Editor features an Inspect and Transform feature, which is a refactoring tool for running various inspections and transformations on the selected scope of files at once. It also enables a user to define a custom inspection.
 
 In this tutorial, you will learn to perform a code review using inspections with refactoring and predefined set of inspections, manage configurations, and create custom inspections.
 
-=== Setting Up the Tutorial Environment
+== Setting Up the Tutorial Environment
 
 In addition to the required software listed above you should have the link:https://netbeans.org/projects/samples/downloads/download/Samples/Java/inspecttransform.zip[+InspectTransform.zip+] file unzipped into your NetBeans project folder and opened in the NetBeans IDE as follows:
 
 image::images/proj.png[]
 
 
-=== Running Inspections
+== Running Inspections
 
 The Single Inspection option in the Inspect and Transform dialog box (Refactor > Inspect and Transform) offers a big variety of inspections related to particular refactoring transformations. The complete list of such operations is available in the Manage Inspections dialog box after clicking the Browse button to the right of the Single Inspection option.
 
@@ -79,7 +77,7 @@ image::images/single-inspection-small.png[role="left", link="images/single-inspe
 
 <<top,top>>
 
-=== Using Configurations
+== Using Configurations
 
 A set of refactorings grouped together constitute a configuration that can be run on your scope of interest, for example, a class or several classes, packages, or projects. The IDE offers the following predefined configurations:
 
@@ -90,7 +88,7 @@ A set of refactorings grouped together constitute a configuration that can be ru
 
 NOTE: Not all releases of the JDK introduce new language features. 
 
-==== Migrate to JDK 5
+=== Migrate to JDK 5
 
 The  ``Migrate to JDK 5``  configuration available in the IDE by default incorporates such refactoring operations as static imports, JDK 5 for-loop usage, unnecessary boxing and unboxing, and switch over Strings application.
 
@@ -101,7 +99,7 @@ image::images/jdk5-conf-small.png[role="left", link="images/jdk5-conf.png"]
 
 NOTE: The list of refactorings in the configuration can be modified in the Inspections list of the Manage Inspections dialog box by selecting and deselecting the items under the  ``JDK Migration Support``  node.
 
-==== Migrate to JDK 7
+=== Migrate to JDK 7
 
 The  ``Migrate to JDK 7``  configuration available in the IDE by default incorporates such refactoring operations as diamond operator usage, try-with-resources conversion, multicatch usage, switch over Strings application, and others.
 
@@ -127,7 +125,7 @@ image::images/jdk7-ref-small.png[role="left", link="images/jdk7-ref.png"]
 
 5. Click Do Refactoring to apply the changes if required.
 
-==== Migrate to JDK 8
+=== Migrate to JDK 8
 
 The  ``Migrate to JDK 8``  configuration available in the IDE by default incorporates such refactoring operations as Lambda or Member Reference conversion, static imports, multicatch usage, switch over Strings application, and others.
 
@@ -138,7 +136,7 @@ image::images/jdk8-conf-small.png[role="left", link="images/jdk8-conf.png"]
 
 NOTE: The list of refactorings in the configuration can be modified in the Inspections list of the Manage Inspections dialog box by selecting and deselecting the items under the  ``JDK Migration Support``  node.
 
-==== Organize Imports
+=== Organize Imports
 
 The  ``Organize Imports``  configuration enables you to inspect the way import statements are organized in the code and refactor your code if desired. By default it includes a single inspection that checks whether import statements correspond to the specified code style rules.
 
@@ -173,7 +171,7 @@ image::images/imports-ref-small.png[role="left", link="images/imports-ref.png"]
 
 <<top,top>>
 
-=== Managing Custom Inspections
+== Managing Custom Inspections
 
 A custom inspection can be created to instruct the IDE what code structures are to be found and how to transform them.
 
@@ -227,7 +225,7 @@ The suggested refactoring changes display in the preview panel.
 
 <<top,top>>
 
-=== Summary
+== Summary
 
 This tutorial covers most frequent usages of the Inspect and Transform feature. Please note that with the Inspect and Transform functionality you can also perform custom refactoring at project scope, or apply particular refactoring configurations to several projects open in the IDE, etc.
 

--- a/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart.asciidoc
@@ -28,11 +28,9 @@
 :description: Introduction to Groovy - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, Introduction to Groovy
 
-== Introduction to Groovy
-
 This document gets you started with link:http://groovy.codehaus.org/[+Groovy+] in NetBeans IDE. You will create a Java application, add a JFrame, and retrieve a simple message from a Groovy file.
 
-=== Creating the Application
+== Creating the Application
 
 In this section you will create a new Java application.
 
@@ -43,7 +41,7 @@ In this section you will create a new Java application.
 
 When you click Finish the IDE creates the project and displays a project node in the Projects window.
 
-=== Creating the Java Class and the Groovy File
+== Creating the Java Class and the Groovy File
 
 In this section you will create a JFrame and a Groovy class.
 
@@ -69,7 +67,7 @@ When you click Finish the IDE creates the Groovy file and opens the file in the 
 
 If you expand the project node in the Projects window you can see that the two files that you created are under the Source Packages node.
 
-=== Calling Groovy from Java
+== Calling Groovy from Java
 
 In this section, you will code the interaction between the Groovy file and the Java class.
 

--- a/netbeans.apache.org/src/content/kb/docs/java/index.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/index.asciidoc
@@ -17,7 +17,7 @@
 //     under the License.
 //
 
-= Java Tutorials
+= Java SE Learning Trail
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
@@ -25,18 +25,16 @@
 :toc-title:
 :description: Java Tutorials
 
-== Java SE Learning Trail
-
 This learning trail is focused on Java SE applications. A Java SE application is an application written to the Java Platform, Standard Edition (Java SE). The same unmodified Java SE applications can be run on almost any computer, whether that computer uses the Microsoft Windows, Solaris, Linux, or OS X operating systems. The key to this application portability is the Java Runtime Environment, which is available free of charge for most operating systems, including all of the ones mentioned above.
 
 In addition to being a platform for multi-platform desktop applications, the Java SE platform is the basis for other technologies such as Java Platform, Enterprise Edition. You might find yourself writing Java code that provides back-end server logic for web and enterprise applications as well.
 
-=== Getting Started
+== Getting Started
 
 - link:quickstart.html[Java Quick Start Tutorial]
 - link:editor-codereference.html[ Code Assistance in the NetBeans IDE Java Editor: A Reference Guide]
 
-=== Developing Java Applications
+== Developing Java Applications
 
 - link:javase-intro.html[Developing General Java Applications]
 - link:code-inspect.html[Static Code Analysis in the NetBeans IDE Java Editor]
@@ -44,33 +42,33 @@ In addition to being a platform for multi-platform desktop applications, the Jav
 - link:javase-embedded.html[Using Oracle Java SE Embedded Support in NetBeans IDE]
 - link:javase-deploy.html[Packaging and Distributing Java Desktop Applications]
 
-=== Building, Debugging, and Testing
+== Building, Debugging, and Testing
 
 - link:debug-visual.html[Using the Visual Debugger in NetBeans IDE]
 - link:junit-intro.html[Writing JUnit Tests in NetBeans IDE]
 - link:debug-multithreaded.html[Debugging Multi-threaded Applications in NetBeans IDE]
 
-=== Maven
+== Maven
 
 - link:http://wiki.netbeans.org/MavenBestPractices[Maven Best Practices]
 - link:maven-hib-java-se.html[Creating a Maven Swing Application Using Hibernate - NetBeans IDE Tutorial]
 
-=== Profiling Source Code
+== Profiling Source Code
 
 - link:profiler-intro.html[Introduction to Profiling Java Applications in NetBeans IDE]
 - link:profiler-profilingpoints.html[Using Profiling Points in NetBeans IDE]
 
-=== Scripting Languages
+== Scripting Languages
 
 - link:groovy-quickstart.html[Introduction to Groovy]
 
-=== JavaFX
+== JavaFX
 
 - link:https://docs.oracle.com/javafx/2/get_started/jfxpub-get_started.htm[Getting Started with JavaFX]
 - link:https://docs.oracle.com/javafx/2/overview/jfxpub-overview.htm[What Is JavaFX?]
 - link:https://docs.oracle.com/javafx/2/architecture/jfxpub-architecture.htm[JavaFX Architecture]
 
-=== Java Swing
+== Java Swing
 
 - link:gui-functionality.html[Introduction to GUI Building]
 - link:native_pkg.html[Native Packaging in NetBeans IDE]

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-deploy.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-deploy.asciidoc
@@ -29,8 +29,6 @@
 :description: Packaging and Distributing Java Desktop Applications - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, Packaging and Distributing Java Desktop Applications
 
-== Packaging and Distributing Java Desktop Applications
-
 One question that a lot of beginning programmers have is: "Now that I've created my application in the IDE, how do I get it to work from the command line outside of the IDE." Similarly, someone might ask, "How do I distribute this application to other users without having to give them the whole IDE as well?"
 
 The answers to these questions are relatively simple, but not necessarily obvious. This document addresses those questions by taking you through the basics of using the IDE to prepare your applications for distribution and deployment. In addition, this document provides information that you might need to configure your system (or which you might need to pass on to the users of your application). We will show a few different approaches for deploying an application, so that users can access the application by:
@@ -41,7 +39,7 @@ The answers to these questions are relatively simple, but not necessarily obviou
 
 NOTE: To complete this tutorial, you need the link:https://netbeans.org/projects/samples/downloads/download/Samples%252FJava%252FDeploymentTutorial.zip[+Deployment Tutorial source files+].
 
-=== Creating Executable JAR File
+== Creating Executable JAR File
 
 This part of the tutorial shows how you can create a distributable application in the IDE and then run that application from outside of the IDE. We will package the application in the form of an executable link:http://download.oracle.com/javase/tutorial/deployment/jar/run.html[+JAR+] file.
 
@@ -51,7 +49,7 @@ In this exercise, you create an IDE project and then place two pre-written Java 
 
 The classes used in this tutorial implement features of the link:http://www.gnu.org/software/grep/[+GNU grep+] utility, which can be used for searching text or regular expression patterns inside text files. The project contains both command-line and GUI versions of the application, so that you can see different ways of running the application.
 
-==== Creating a Project with Existing Sources
+=== Creating a Project with Existing Sources
 
 1. Download the link:https://netbeans.org/projects/samples/downloads/download/Samples%252FJava%252FDeploymentTutorial.zip[+DeploymentTutorial.zip+] file and extract its contents on your system. 
 This zip archive contains source files for the application plus a few other files that will be used in the tutorial.
@@ -72,7 +70,7 @@ NOTE: If, for example, you want to exclude some source files from importing into
 
 The project opens in the IDE and becomes visible in the Projects window. You can explore the contents of the project by expanding the project's Source Packages node, where you should see classes called  ``Grep``  and  ``xGrep`` .  ``Grep.java``  is a console version of the application.  ``xGrep.java``  is a GUI version of the application and uses methods defined in  ``Grep.java`` .
 
-==== Configuring the Project
+=== Configuring the Project
 
 There are a few configuration steps you need to do, such as:
 
@@ -80,7 +78,7 @@ There are a few configuration steps you need to do, such as:
 * Set the project's main class. By doing this, you ensure that the JAR file that you create when you build the project is executable.
 
 
-===== Verifying the Java Platform
+==== Verifying the Java Platform
 
 Our project needs to be compiled and run on Java 7 or Java 8 platform. Therefore, you need to make sure that Java 7 or Java 8 is respectively used as the platform for this project.
 
@@ -90,7 +88,7 @@ Our project needs to be compiled and run on Java 7 or Java 8 platform. Therefore
 4. Click OK to close the Properties window.
 
 
-===== Setting the Main Class
+==== Setting the Main Class
 
 In order for a user to easily run your JAR file (by double-clicking the JAR file or by typing  ``java -jar AnotherGrep.jar``  at the command line), a main class has to be specified inside the JAR's _manifest_ file. (The manifest is a standard part of the JAR file that contains information about the JAR file that is useful for the  ``java``  launcher when you want to run the application.) The main class serves as an entry point from which the  ``java``  launcher runs your application.
 
@@ -111,7 +109,7 @@ When you build the project later in this tutorial, the manifest will be generate
 Main-Class: anothergrep.xGrep
 ----
 
-==== Building the Project and Creating the JAR File
+=== Building the Project and Creating the JAR File
 
 Now that you have your sources ready and your project configured, it is time to build your project.
 
@@ -139,9 +137,9 @@ Main-Class: anothergrep.xGrep
 
 (To find more about manifest files, you can read link:http://java.sun.com/docs/books/tutorial/deployment/jar/manifestindex.html[+this chapter+] from the Java Tutorial.)
 
-=== Running and Distributing the JAR File
+== Running and Distributing the JAR File
 
-==== Running the Application Inside of the IDE
+=== Running the Application Inside of the IDE
 
 When developing applications in the IDE, typically you will need to test and refine them before distributing. You can easily test an application that you are working on by running the application from the IDE.
 
@@ -151,7 +149,7 @@ The xGrep window should open. You can click the Browse button to choose a file i
 
 Information on regular expressions that you can use in this application are available link:http://www.gnu.org/software/grep/manual/html_node/Regular-Expressions.html#Regular-Expressions[+here+] and in many other places.
 
-==== Running the Application Outside of the IDE
+=== Running the Application Outside of the IDE
 
 Once you have finished developing the application and before you distribute it, you will probably want to make sure that the application also works outside of the IDE.
 
@@ -163,7 +161,7 @@ You will know that the application has started successfully when the xGrep windo
 
 If the xGrep window does not open, your system probably does not have a file association between JAR files and the Java Runtime Environment. See <<troubleshooting,Troubleshooting JAR File Associations>> below.
 
-==== Distributing the Application to Other Users
+=== Distributing the Application to Other Users
 
 Now that you have verified that the application works outside of the IDE, you are ready to distribute it.
 
@@ -172,7 +170,7 @@ Now that you have verified that the application works outside of the IDE, you ar
 NOTE: If your application depends on additional libraries other than those included in JDK, you need to also include them in your distribution (not the case in our example). The relative paths to these libraries are added in the  ``classpath``  entry of the JAR's manifest file when you are developing your application in the IDE. If these additional libraries will not be found at the specified classpath (i.e., relative path) at launch, the application will not start. 
 Create a zip archive that contains the application JAR file and the library and provide this zip file to users. Instruct the users to unpack the zip file making sure that the JAR file and libraries JAR files are in the same folder. Run the application JAR file.
 
-=== Starting Your Java Application
+== Starting Your Java Application
 
 The goal of this exercise is to show you some ways that you can start your application from the command line.
 
@@ -181,7 +179,7 @@ This exercise shows you how you can start a Java application in the following tw
 * Running the  ``java``  command from the command line.
 * Using a script to a call a class in the JAR file.
 
-==== Launching Applications From the Command Line
+=== Launching Applications From the Command Line
 
 You can launch an application from the command line by using the  ``java``  command. If you want to run an executable JAR file, use the  ``-jar``  option of the command.
 
@@ -208,7 +206,7 @@ C:\Program Files\Java\jdk1.7.0_51\bin\java -jar AnotherGrep.jar
 ----
 * Add the Java binaries to your PATH environment variable, so that you never have to specify the path to the  ``java``  binary from the command line. See <<path,Setting the PATH Environment Variable>>.
 
-==== Launching Applications From a Script
+=== Launching Applications From a Script
 
 If the application that you want to distribute is a console application, you might find that it is convenient to start the application from a a script, particularly if the application takes long and complex arguments to run. In this section, you will use a console version of the Grep program, where you need to pass the arguments (search pattern and file list) to the JAR file, which will be invoked in our script. To reduce typing at the command line, you will use a simple script suitable to run the test application.
 
@@ -220,7 +218,7 @@ First you need to change the main class in the application to be the console ver
 
 After completing these steps, the JAR file is rebuilt, and the  ``Main-Class``  attribute of the JAR file's manifest is changed to point to  ``anothergrep.Grep`` .
 
-===== link:http://www.gnu.org/software/bash/bash.html[+BASH+] script -- for UNIX and Linux machines
+==== link:http://www.gnu.org/software/bash/bash.html[+BASH+] script -- for UNIX and Linux machines
 
 Inside the folder on your system where you extracted the contents of the link:https://netbeans.org/projects/samples/downloads/download/Samples%252FJava%252FDeploymentTutorial.zip[+DeploymentTutorial.zip+] file, there is a  ``grep.sh``  bash script. Have a look at it:
 
@@ -238,7 +236,7 @@ This script presumes that the Java binaries are part of your PATH environment va
 
 More about bash scripting can be found link:http://www.gnu.org/software/bash/manual/bashref.html[+here+].
 
-===== .bat script for Windows machines
+==== .bat script for Windows machines
 
 On Microsoft Windows systems, you can only pass nine arguments at once to a batch file. If there were more than nine arguments, you would need to execute the JAR file multiple times.
 
@@ -271,9 +269,9 @@ You can see that only nine arguments are passed to the program at a time (in one
 
 More about batch scripting can be found on link:http://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/batch.mspx[+this page+].
 
-=== Troubleshooting Tips
+== Troubleshooting Tips
 
-==== Specifying JAR File Associations
+=== Specifying JAR File Associations
 
 On most systems, you can execute an executable JAR file by simply double-clicking the JAR file. If nothing happens when you double-click the JAR file, it might be because of either of the following two reasons:
 
@@ -337,7 +335,7 @@ NOTE: Starting with Windows Vista advanced file associations can be set via RegE
 
 For UNIX and Linux systems, the procedure for changing file associations depends on which desktop environment (such as GNOME or KDE) that you are using. Look in your desktop environment's preference settings or consult the documentation for the desktop environment.
 
-==== Setting the PATH Environment Variable
+=== Setting the PATH Environment Variable
 
 If you can not run a Java class or JAR file on your system without pointing to the location of the JDK or JRE on your system, you might need to modify the value of your system's  ``PATH``  variable.
 

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-embedded.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-embedded.asciidoc
@@ -29,13 +29,11 @@
 :description: Using Oracle Java SE Embedded Support in NetBeans IDE - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, Using Oracle Java SE Embedded Support in NetBeans IDE
 
-== Using Oracle Java SE Embedded Support in NetBeans IDE
-
 link:http://www.oracle.com/technetwork/java/embedded/overview/javase/index.html[+Oracle Java Standard Edition Embedded+] (Oracle Java SE Embedded) enables users to develop highly functional, reliable and portable applications for powerful embedded systems. NetBeans IDE supports Java SE Embedded features, such as footprint, memory, power, platform support, etc.
 
 In this tutorial, you will learn how to get started with Java SE Embedded in NetBeans IDE and how to use the IDE support for Java SE Embedded.
 
-=== Setting Up a Remote Platform in NetBeans IDE
+== Setting Up a Remote Platform in NetBeans IDE
 
 Once link:http://www.oracle.com/technetwork/java/embedded/downloads/javase/index.html?ssSourceSiteId=otncn[+Oracle Java SE Embedded+] runtime is downloaded and installed on your remote machine (Raspberry Pi is used for demonstration purposes in this tutorial), you need to set up NetBeans IDE with the remote platform as follows:
 
@@ -92,7 +90,7 @@ image::images/jpremote-small.png[role="left", link="images/jpremote.png"]
 
 Now your NetBeans IDE is set up for remote Java SE development.
 
-=== Creating and Running a Project in the IDE
+== Creating and Running a Project in the IDE
 
 Now let us create a project that is going to be first run in the IDE and then on the remote platform.
 
@@ -128,7 +126,7 @@ To test your application, right-click the project name and choose Run from the c
 
 image::images/run-ide.png[]
 
-==== Configuring a Project to Use a Remote Platform
+=== Configuring a Project to Use a Remote Platform
 
 To develop a Java SE embedded application on a remote platform using link:http://openjdk.java.net/jeps/161[+compact1, compact2, or compact3 runtime platforms+], JDK 8 needs to be registered in the IDE.
 
@@ -181,7 +179,7 @@ image::images/prj-jdk8-profile-small.png[role="left", link="images/prj-jdk8-prof
 5. Click OK to save the changes. 
 Your project is set to recognize a particular runtime on a remote platform.
 
-=== Running a Project on a Remote Platfrom
+== Running a Project on a Remote Platfrom
 
 You can run and debug the application on a remote device after setting the project configuration to a configuration different from the default one.
 

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-intro.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-intro.asciidoc
@@ -30,15 +30,13 @@
 :description: Developing General Java Applications - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, Developing General Java Applications
 
-== Developing General Java Applications
-
 The following short tutorial takes you through some of the basic steps of developing a Java SE application in NetBeans IDE. This tutorial assumes you already have some familiarity with developing Java applications. Along the way, you will see some of the IDE features that simplify application development.
 
 You will create an application that converts several words into a single word that contains one letter from each of the other words. The resulting word is called an _acrostic_.
 
 This tutorial takes approximately 30 minutes to complete. If you would like to do a quicker "Hello World" tutorial, see the link:quickstart.html[+NetBeans IDE Java Quick Start Tutorial+].
 
-=== Project Setup 
+== Project Setup 
 
 The application you create will contain two projects:
 
@@ -49,7 +47,7 @@ After you create the projects, you will add the library project to the classpath
 
 NOTE: Strictly speaking, two projects are not needed for such a simple application. This tutorial uses two projects to demonstrate features that you might need for a more complex application.
 
-==== Creating a Java Class Library Project
+=== Creating a Java Class Library Project
 
 1. Choose File > New Project (Ctrl-Shift-N). Under Categories, select Java. Under Projects, select Java Class Library. Click Next.
 2. Under Project Name, type `MyLib`. Change the Project Location to any directory on your computer. From now on, this tutorial refers to this directory as `_NetBeansProjects_`.
@@ -59,7 +57,7 @@ NOTE: The path specified above should appear as follows in the Project Folder fi
 3. (Optional) Select the Use Dedicated Folder for Storing Libraries checkbox and specify the location for the libraries folder. See link:http://www.oracle.com/pls/topic/lookup?ctx=nb8000&id=NBDAG455[+Sharing a Library with Other Users+] in _Developing Applications with NetBeans IDE_ for more information on this option.
 4. Click Finish. The MyLib project opens in both the Projects window and the Files window.
 
-==== Creating a Java Application Project
+=== Creating a Java Application Project
 
 1. Choose File > New Project. Under Categories, select Java. Under Projects, select Java Application. Click Next.
 2. Under Project Name, type `MyApp`. Make sure the Project Location is set to `_NetBeansProjects_`.
@@ -68,7 +66,7 @@ NOTE: The path specified above should appear as follows in the Project Folder fi
 5. Ensure that the Create Main Class checkbox is checked.
 6. Click Finish. The MyApp project is displayed in the Project window and `Main.java` opens in the Source Editor.
 
-==== Configuring the Compilation Classpath
+=== Configuring the Compilation Classpath
 
 Since MyApp is going to depend on a class in MyLib, you have to add MyLib to the classpath of MyApp. Doing so also ensures that classes in the MyApp project can refer to classes in the MyLib project without causing compilation errors. In addition, this enables you to use code completion in the MyApp project to fill in code based on the MyLib project. In the IDE, the classpath is visually represented by the Libraries node.
 
@@ -82,11 +80,11 @@ image::images/addproj.png[]
 3. Click Add Project JAR Files.
 4. Expand the Libraries node. The MyLib project's JAR file is added to the MyApp project's classpath.
 
-=== Creating and Editing Java Source Code 
+== Creating and Editing Java Source Code 
 
 Now you need to create a Java package and add the method that you will use to construct the acrostic. After that you need to implement the `acrostic` method in the `Main` class.
 
-==== Creating a Java Package and Class File
+=== Creating a Java Package and Class File
 
 1. Right-click the MyLib project node and choose New > Java Class. Type `LibClass` as the name for the new class, type `org.me.mylib` in the Package field, and click Finish. `LibClass.java` opens in the Source Editor.
 2. In `LibClass.java`, place the cursor on the line after the class declaration (`public class LibClass {`.
@@ -110,7 +108,7 @@ Now you need to create a Java package and add the method that you will use to co
 4. If the code that you pasted in is not formatted correctly, press Alt-Shift-F to reformat the entire file.
 5. Press Ctrl-S to save the file.
 
-==== Editing a Java File
+=== Editing a Java File
 
 Now you will add some code to `Main.java`. In doing so, you will see the Source Editor's code completion and code template (abbreviation) features.
 
@@ -165,13 +163,13 @@ System.out.println("Result = " + result);
 
 NOTE: `sout` is one of many code templates that are available in the Source Editor. To find and edit the list of code templates, choose Tools > Options > Editor > Code Template.
 
-=== Compiling and Running the Application 
+== Compiling and Running the Application 
 
 Now you need to set the main class and execution arguments so that you can run the project.
 
 NOTE: By default, the projects have been created with the Compile on Save feature enabled, so you do not need to compile your code first in order to run the application in the IDE. For more information, see link:http://www.oracle.com/pls/topic/lookup?ctx=nb8000&id=NBDAG525[+Compiling a Single Java File+] in _Developing Applications with NetBeans IDE_.
 
-==== Setting the Main Class and Execution Arguments
+=== Setting the Main Class and Execution Arguments
 
 The output of this program is based on arguments that you provide when you run the program. As arguments, you will provide five words, from which the acrostic "Hello" will be generated. The acrostic is assembled from the first letter of the first word, the second letter of the second word, the third letter of the third word, and so on.
 
@@ -183,7 +181,7 @@ The main class should already be set to `acrostic.Main`.
 
 2. Type `However we all feel zealous `in the Arguments field and click OK.
 
-==== Running the Application
+=== Running the Application
 
 Now that you have created the application and provided runtime arguments for the application, you can test run the application in the IDE.
 
@@ -194,11 +192,11 @@ Now that you have created the application and provided runtime arguments for the
 
 In the Output window, you should see the output from the program, `Result = Hello ` (the acrostic of the phrase that was passed to the program as an argument).
 
-=== Testing and Debugging the Application 
+== Testing and Debugging the Application 
 
 Now you will create and run a test for the project using JUnit and then run the application in the IDE's debugger to check for errors. In the JUnit test, you will test the LibClass by passing a phrase to the `acrostic` method and using an assertion to indicate what you think the result should be.
 
-==== Creating JUnit Tests
+=== Creating JUnit Tests
 
 1. Right-click the `LibClass.java` node in the Projects window and choose Tools >Create/Update Tests (Ctrl-Shift-U).
 2. In the Create Tests dialog box, click OK to run the command with the default options.
@@ -218,7 +216,7 @@ assertEquals("Correct value", "foo", result);
 ----
 5. Save the file by pressing Ctrl-S.
 
-==== Running JUnit Tests
+=== Running JUnit Tests
 
 1. Select the MyLib project node and choose Run > Test Project (MyLib) or press Alt-F6. The` MyLib (test)` tab opens in the Output window. The JUnit test cases are compiled and run. The JUnit test result shows that the test passes.
 2. You can also run a single test file rather than testing the entire project. Select the `LibClass.java` tab in the Source Editor and choose Run > Test File.
@@ -229,7 +227,7 @@ NOTE: If this is the first time you access Javadoc in the IDE, you need to first
 
 You can learn more about JUnit by visiting link:http://www.junit.org[+http://www.junit.org+]
 
-==== Debugging the Application
+=== Debugging the Application
 
 In this section, you will use the debugger to step through the application and watch the values of variables change as the acrostic is assembled.
 
@@ -244,11 +242,11 @@ When the program reaches the end, the debugger windows close.
 
 For more information, see link:junit-intro.html[+Writing JUnit Tests in NetBeans IDE+].
 
-=== Building, Running, and Distributing the Application
+== Building, Running, and Distributing the Application
 
 Once you are satisfied that your application works properly, you can prepare the application for deployment outside of the IDE. In this section you will build the application's JAR file and then run the JAR file from the command line.
 
-==== Building the Application
+=== Building the Application
 
 The main build command in the IDE is the Clean and Build command. The Clean and Build command deletes previously compiled classes and other build artifacts and then rebuilds the entire project from scratch.
 
@@ -281,7 +279,7 @@ Main-Class: acrostic.Main
 
 (To find more about manifest files, you can read link:http://java.sun.com/docs/books/tutorial/deployment/jar/manifestindex.html[+this chapter+] from the Java Tutorial.)
 
-==== Running the Application Outside of the IDE
+=== Running the Application Outside of the IDE
 
 *To run the application outside of the IDE:*
 
@@ -309,7 +307,7 @@ Result = Hello
 image::images/command-prompt-smaller.png[role="left", link="images/command-prompt.png"]
 --
 
-==== Distributing the Application to Other Users
+=== Distributing the Application to Other Users
 
 Now that you have verified that the application works outside of the IDE, you are ready to distribute the application.
 
@@ -319,11 +317,11 @@ Now that you have verified that the application works outside of the IDE, you ar
 2. Send the file to the people who will use the application. Instruct them to unpack the zip file, making sure that the `MyApp.jar` file and the `lib` folder are in the same folder.
 3. Instruct the users to follow the steps in the <<running-outside-IDE,Running the Application Outside of the IDE>> section above.
 
-=== Other Common Tasks
+== Other Common Tasks
 
 You have now completed the main part of the tutorial, but there are still some basic tasks that have not been covered. This section includes a few of those tasks.
 
-==== Making the Javadoc Available in the IDE
+=== Making the Javadoc Available in the IDE
 
 To view the JavaSE API documentation in the NetBeans IDE, use the Source > Show Documentation command or choose Window > IDE Tools > Javadoc Documentation from the main menu to view API documentation in a separate window.
 
@@ -337,7 +335,7 @@ However, for some third-party libraries, API documentation is not available. In 
 4. Click the Add ZIP/Folder button and navigate to the zip file or the folder that contains the Javadoc API documentation on your system. Select the zip file or the folder and click the Add ZIP/Folder button.
 5. Click Close.
 
-==== Generating Javadoc for a Project
+=== Generating Javadoc for a Project
 
 You can generate compiled Javadoc documentation for your project based on Javadoc comments that you have added to your classes.
 

--- a/netbeans.apache.org/src/content/kb/docs/java/junit-intro.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/junit-intro.asciidoc
@@ -28,8 +28,6 @@
 :description: Writing JUnit Tests in NetBeans IDE - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, Writing JUnit Tests in NetBeans IDE
 
-== Writing JUnit Tests in NetBeans IDE
-
 This tutorial introduces the basics of writing and running JUnit unit tests in NetBeans IDE. Testing an application is an integral part of the development cycle, and writing and maintaining unit tests can help ensure that the individual methods in your source code work correctly. The IDE's integrated support for the JUnit unit testing framework enables you to quickly and easily create JUnit tests and test suites.
 
 In this tutorial you create simple JUnit 3 and JUnit 4 unit tests and test suites for a Java class library project. The first part of the tutorial shows how to create tests in JUnit 3. The second part shows how to create the same tests in JUnit 4 using JUnit annotations. It is not necessary to complete both parts of the tutorial because the tests are the same, but seeing how the tests are written in both versions enables you to see some of the changes introduced in JUnit 4.
@@ -38,11 +36,11 @@ For more on using JUnit, see link:http://www.junit.org[+www.junit.org+].
 
 *To follow this tutorial, you need the link:https://netbeans.org/projects/samples/downloads/download/Samples/Java/JUnitSampleSol.zip[JUnitSampleSol Project].
 
-=== Creating the Project
+== Creating the Project
 
 To complete this tutorial you first create a Java class library project called JUnit-Sample. After you create the project, you copy two classes from the sample project JUnitSampleSol to your project JUnit-Sample.
 
-==== Creating the Java Class Library Project
+=== Creating the Java Class Library Project
 
 1. Choose File > New Project from the main menu.
 2. Select Java Class Library from the Java category and click Next.
@@ -55,7 +53,7 @@ Click Finish.
 
 The first time that you create a JUnit test the IDE prompts you to select a version and then adds a Test Libraries node and the JUnit library.
 
-=== Creating the Java Classes
+== Creating the Java Classes
 
 In this exercise you copy the files  ``Utils.java``  and  ``Vectors.java``  from the sample project JUnitSampleSol into the class library project that you created.
 
@@ -69,13 +67,13 @@ If you look at the source code for the classes, you can see that  ``Utils.java``
 
 *Note.* You can close the JUnitSampleSol project because you will not need it again. The JUnitSampleSol project contains all the tests described in this document.
 
-=== Writing JUnit 3 Unit Tests
+== Writing JUnit 3 Unit Tests
 
 In this part of the tutorial you create basic JUnit 3 unit tests for the classes  ``Vectors.java``  and  ``Utils.java`` . You will use the IDE to create skeleton test classes that are based on the classes in your project. You will then modify the generated test methods and add new test methods.
 
 The IDE prompts you to choose a JUnit version the first time that you use the IDE to create tests for you in the project. The version that you select becomes the default JUnit version and the IDE will generate all subsequent tests and test suites for that version.
 
-==== Creating a Test Class for  ``Vectors.java`` 
+=== Creating a Test Class for  ``Vectors.java`` 
 
 In this exercise you create a JUnit test skeleton for  ``Vectors.java`` . You will also select JUnit as the test framework and JUnit 3 as the version.
 
@@ -143,7 +141,7 @@ When the IDE generates the names for the test methods, each method name is prepe
 
 *Note.* In JUnit 4 it is no longer necessary to use this test method naming syntax because you can use annotations to identify test methods and the test class is no longer required to extend  ``TestCase`` .
 
-==== Writing Test Methods for  ``Vectors.java`` 
+=== Writing Test Methods for  ``Vectors.java`` 
 
 In this exercise you modify the generated test methods to make them functioning tests and modify the default output messages. You do not need to modify the output messages to run the tests, but you may want to modify the output to help identify the results displayed in the JUnit Test Results output window.
 
@@ -226,7 +224,7 @@ This test uses the JUnit  ``assertTrue``  and  ``assertFalse``  methods to test 
 
 Compare: <<Exercise_32,Writing Test Methods for  ``Vectors.java``  (JUnit 4)>>
 
-==== Creating a Test Class for  ``Utils.java`` 
+=== Creating a Test Class for  ``Utils.java`` 
 
 You now create the test skeletons for  ``Utils.java`` . When you created the test in the previous exercise, the IDE prompted you for the version of JUnit. You are not prompted to select a version this time.
 
@@ -237,11 +235,11 @@ You now create the test skeletons for  ``Utils.java`` . When you created the tes
 
 When you click OK, the IDE creates the test file  ``UtilsJUnit3Test.java``  in the Test Packages > samples directory. You can see that in addition to creating the test skeletons  ``testComputeFactorial`` ,  ``testConcatWords`` , and  ``testNormalizeWord``  for the methods in  ``Utils.java`` , the IDE also creates the test initializer method  ``setUp``  and the test finalizer method  ``tearDown`` .
 
-==== Writing Test Methods for  ``Utils.java`` 
+=== Writing Test Methods for  ``Utils.java`` 
 
 In this exercise you add some test cases that illustrate some common JUnit test elements. You also add a  ``println``  to the methods because some methods do not print any output by default. By adding a  ``println``  to the methods you can later look in the JUnit test result window to see if the methods were run and the order in which they were run.
 
-===== Test Initializers and Finalizers
+==== Test Initializers and Finalizers
 
 The  ``setUp``  and  ``tearDown``  methods are used to initialize and finalize test conditions. You do not need the  ``setUp``  and  ``tearDown``  methods to test  ``Utils.java`` , but they are included here to demonstrate how they work.
 
@@ -269,7 +267,7 @@ protected void tearDown() throws Exception {
 
 When you run the test the  ``println``  text for each methods will appear in the JUnit Test Results output window. If you do not add the  ``println`` , there is no output to show that the methods were run.
 
-===== Testing Using a Simple Assertion
+==== Testing Using a Simple Assertion
 
 This simple test case tests the  ``concatWords``  method. Instead of using the generated test method  ``testConcatWords`` , you will add a new test method called  ``testHelloWorld``  that uses a single simple assertion to test if the method concatenates the strings correctly. The  ``assertEquals``  in the test case uses the syntax  ``assertEquals(_EXPECTED_RESULT, ACTUAL_RESULT_)``  to test if the expected result is equal to the actual result. In this case, if the input to the method  ``concatWords``  is " ``Hello`` ", " ``, `` ", " ``world`` " and " ``!`` ", the expected result should equal  ``"Hello, world!"`` .
 
@@ -289,7 +287,7 @@ public void testHelloWorld() {
 
 Compare: <<Exercise_342,Testing Using a Simple Assertion (JUnit 4)>>
 
-===== Testing Using a Timeout
+==== Testing Using a Timeout
 
 This test demonstrates how to check if a method is taking too long to complete. If the method is taking too long, the test thread is interrupted and the test fails. You can specify the time limit in the test.
 
@@ -344,7 +342,7 @@ public void testWithTimeout() throws InterruptedException, TimeoutException {
 
 Compare: <<Exercise_343,Testing Using a Timeout (JUnit 4)>>
 
-===== Testing for an Expected Exception
+==== Testing for an Expected Exception
 
 This test demonstrates how to test for an expected exception. The method fails if it does not throw the specified expected exception. In this case you are testing that the  ``computeFactorial``  method throws an  ``IllegalArgumentException``  if the input variable is a negative number (-5).
 
@@ -368,7 +366,7 @@ public void testExpectedException() {
 
 Compare: <<Exercise_344,Testing for an Expected Exception (JUnit 4)>>
 
-===== Disabling a Test
+==== Disabling a Test
 
 This test demonstrates how to temporarily disable a test method. In JUnit 3, if a method name does not start with  ``test``  it is not recognized as a test method. In this case you prepend  ``DISABLED_``  to the name of the test method to disable it.
 
@@ -395,7 +393,7 @@ Compare: <<Exercise_345,Disabling a Test (JUnit 4)>>
 
 Now that you have written the tests, you can run the test and see the test output in the JUnit Test Results window.
 
-==== Running the Tests
+=== Running the Tests
 
 When you run a JUnit test the results are displayed in the Test Results window of the IDE. You can run individual JUnit test classes or you can choose Run > Test _PROJECT_NAME_ from the main menu to run all the tests for the project. If you choose Run > Test, the IDE runs all the test classes in the Test Packages folder. To run an individual test class, right-click the test class under the Test Packages node and choose Run File.
 
@@ -421,7 +419,7 @@ In this image (click the image to see a larger image) you can see that the proje
 
 The next step after you create your unit test classes is to create test suites. See <<Exercise_41,Creating JUnit 3 Test Suites>> to see how to run specified tests as a group so you do not have to run each test individually.
 
-=== Writing JUnit 4 Tests
+== Writing JUnit 4 Tests
 
 In this exercise you create JUnit 4 unit tests for the classes  ``Vectors.java``  and  ``Utils.java`` . The JUnit 4 test cases are the same as the JUnit 3 test cases, but you will see that the syntax for writing the tests is simpler.
 
@@ -429,7 +427,7 @@ You will use the IDE's wizards to create test skeletons based on the classes in 
 
 *Note.* If you already selected JUnit 3.x as the default version for your tests, you need to change the default version to JUnit 4.x. To change the default JUnit version, expand the Test Libraries node, right-click the JUnit library and choose Remove. You can now use the Add Library dialog box to explicitly add the JUnit 4 library or you can select version 4.x when you are prompted to select the JUnit version when you create a new test. You can still run JUnit 3 tests, but any new tests you create will use JUnit 4.
 
-==== Creating a Test Class for  ``Vectors.java`` 
+=== Creating a Test Class for  ``Vectors.java`` 
 
 In this exercise you will create the JUnit test skeletons for  ``Vectors.java`` .
 
@@ -477,7 +475,7 @@ You can configure the methods that are generated by default by configuring the J
 
 *Note.* For JUnit 4 tests, notice that by default the IDE adds a static import declaration for  ``org.junit.Assert.*`` .
 
-==== Writing Test Methods for  ``Vectors.java`` 
+=== Writing Test Methods for  ``Vectors.java`` 
 
 In this exercise you modify each of the generated test methods to test the methods using the JUnit  ``assert``  method and to change the names of the test methods. In JUnit 4 you have greater flexibility when naming test methods because test methods are indicated by the  ``@Test``  annotation and do not require the word  ``test``  prepended to test method names.
 
@@ -561,7 +559,7 @@ This test uses the JUnit  ``assertTrue``  and  ``assertFalse``  methods to test 
 
 Compare: <<Exercise_22,Writing Test Methods for  ``Vectors.java``  (JUnit 3)>>
 
-==== Creating a Test Class for  ``Utils.java`` 
+=== Creating a Test Class for  ``Utils.java`` 
 
 You will now create the JUnit test methods for  ``Utils.java`` . When you created the test class in the previous exercise, the IDE prompted you for the version of JUnit. You are not prompted to select a version this time because you already selected the JUnit version and all subsequent JUnit tests are created in that version.
 
@@ -574,11 +572,11 @@ You will now create the JUnit test methods for  ``Utils.java`` . When you create
 
 When you click OK, the IDE creates the test file  ``UtilsJUnit4Test.java``  in the Test Packages > sample directory. You can see that the IDE generated the test methods  ``testComputeFactorial`` ,  ``testConcatWords`` , and  ``testNormalizeWord``  for the methods in  ``Utils.java`` . The IDE also generated initializer and finalizer methods for the test and the test class.
 
-==== Writing Test Methods for  ``Utils.java`` 
+=== Writing Test Methods for  ``Utils.java`` 
 
 In this exercise you will add test cases that illustrate some common JUnit test elements. You will also add a  ``println``  to the methods because some methods do not print any output to the JUnit Test Results window to indicate that they were run, or to indicate that the method passed the test. By adding a  ``println``  to the methods you can see if the methods were run and the order in which they were run.
 
-===== Test Initializers and Finalizers
+==== Test Initializers and Finalizers
 
 When you created the test class for  ``Utils.java``  the IDE generated annotated initializer and finalizer methods. You can choose any name for the name of the method because there is no required naming convention.
 
@@ -622,7 +620,7 @@ Compare: <<Exercise_241,Test initializers and finalizers (JUnit 3)>>
 
 When you run the test class the  ``println``  text you added is displayed in the output pane of the JUnit Test Results window. If you do not add the  ``println`` , there is no output to indicate that the initializer and finalizer methods were run.
 
-===== Testing Using a Simple Assertion
+==== Testing Using a Simple Assertion
 
 This simple test case tests the  ``concatWords``  method. Instead of using the generated test method  ``testConcatWords`` , you will add a new test method called  ``helloWorldCheck``  that uses a single simple assertion to test if the method concatenates the strings correctly. The  ``assertEquals``  in the test case uses the syntax  ``assertEquals(_EXPECTED_RESULT, ACTUAL_RESULT_)``  to test if the expected result is equal to the actual result. In this case, if the input to the method  ``concatWords``  is " ``Hello`` ", " ``,`` ", " ``world`` " and " ``!`` ", the expected result should equal  ``"Hello, world!"`` .
 
@@ -644,7 +642,7 @@ public void helloWorldCheck() {
 
 Compare: <<Exercise_242,Testing Using a Simple Assertion (JUnit 3)>>
 
-===== Testing Using a Timeout
+==== Testing Using a Timeout
 
 This test demonstrates how to check if a method is taking too long to complete. If the method is taking too long, the test thread is interrupted and the test fails. You can specify the time limit in the test.
 
@@ -684,7 +682,7 @@ public void testWithTimeout() {
 
 Compare: <<Exercise_243,Testing Using a Timeout (JUnit 3)>>
 
-===== Testing for an Expected Exception
+==== Testing for an Expected Exception
 
 This test demonstrates how to test for an expected exception. The method fails if it does not throw the specified expected exception. In this case you are testing that the  ``computeFactorial``  method throws an  ``IllegalArgumentException``  if the input variable is a negative number (-5).
 
@@ -719,7 +717,7 @@ public void checkExpectedException() {
 
 Compare: <<Exercise_244,Testing for an Expected Exception (JUnit 3)>>
 
-===== Disabling a Test
+==== Disabling a Test
 
 This test demonstrates how to temporarily disable a test method. In JUnit 4 you simply add the  ``@Ignore``  annotation to disable the test.
 
@@ -749,7 +747,7 @@ Compare: <<Exercise_245,Disabling a Test (JUnit 3)>>
 
 Now that you have written the tests you can run the test and see the test output in the JUnit Test Results window.
 
-==== Running the Tests
+=== Running the Tests
 
 You can run JUnit tests on the entire application or on individual files and see the results in the IDE. The easiest way to run all the unit tests for the project is to choose Run > Test _<PROJECT_NAME>_ from the main menu. If you choose this method, the IDE runs all the test classes in the Test Packages. To run an individual test class, right-click the test class under the Test Packages node and choose Run File.
 
@@ -774,7 +772,7 @@ When you right-click a test result in the Test Results window, the popup menu en
 
 The next step after creating your unit test classes is to create test suites. See <<Exercise_42,Creating JUnit 4 Test Suites>> to see how to run specified tests as a group so you do not have to run each test individually.
 
-=== Creating Test Suites
+== Creating Test Suites
 
 When creating tests for a project you will generally end up with many test classes. While you can run test classes individually or run all the tests in a project, in many cases you will want to run a subset of the tests or run tests in a specific order. You can do this by creating one or more test suites. For example, you can create test suites that test specific aspects of your code or specific conditions.
 
@@ -782,7 +780,7 @@ A test suite is basically a class with a method that invokes the specified test 
 
 You can create JUnit 3 and JUnit 4 test suites for your project manually or the IDE can generate the suites for you. When you use the IDE to generate a test suite, by default the IDE generates code to invoke all the test classes in the same package as the test suite. After the test suite is created you can modify the class to specify the tests you want to run as part of that suite.
 
-==== Creating JUnit 3 Test Suites
+=== Creating JUnit 3 Test Suites
 
 If you selected JUnit 3 as the version for your tests, the IDE can generate JUnit 3 test suites based on the test classes in the test package. In JUnit 3 you specify the test classes to include in the test suite by creating an instance of  ``TestSuite``  and using the  ``addTest``  method for each test.
 
@@ -828,7 +826,7 @@ public static Test suite() {
 ----
 7. Save your changes.
  
-==== Creating JUnit 4 Test Suites
+=== Creating JUnit 4 Test Suites
 
 If you selected JUnit 4 for the version of your tests, the IDE can generate JUnit 4 test suites. JUnit 4 is back-compatible so you can run JUnit 4 test suites that contain JUnit 4 and JUnit 3 tests. In JUnit 4 test suites you specify the test classes to include as values of the  ``@Suite``  annotation.
 
@@ -854,7 +852,7 @@ public class JUnit4TestSuite {
 
 When you run the test suite the IDE will run the test classes in the order that they are listed.
 
-==== Running Test Suites
+=== Running Test Suites
 
 You run a test suite the same way you run any individual test class.
 
@@ -884,7 +882,7 @@ image:images/junitmix3and4-suite-results-sm.png[role="left", link="images/junitm
 
 In this image (click the image to see a larger image) you can see the test results for a mixed test suite. This test suite includes the JUnit 4 test suite and one of the JUnit 3 test classes. The test suite ran the  ``UtilsJUnit3Test.java``  and  ``JUnit4TestSuite.java``  test classes as a single test and displayed the test results in the left pane as the results of a single test. The output in the right pane is the same as running the test individually.
 
-=== Conclusion
+== Conclusion
 
 This tutorial has given you a basic introduction to creating JUnit unit tests and test suites in NetBeans IDE. The IDE supports JUnit 3 and JUnit 4, and this document demonstrated some of the changes introduced in JUnit 4 that are designed to make creating and running tests simpler.
 

--- a/netbeans.apache.org/src/content/kb/docs/java/maven-hib-java-se.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/maven-hib-java-se.asciidoc
@@ -29,8 +29,6 @@
 :description: Creating a Maven Swing Application Using Hibernate - NetBeans IDE Tutorial - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, Creating a Maven Swing Application Using Hibernate - NetBeans IDE Tutorial
 
-== Creating a Maven Swing Application Using Hibernate - NetBeans IDE Tutorial
-
 In this tutorial, you use the NetBeans IDE to create a Java Swing application from a Maven archetype. The application uses the Hibernate framework as the persistence layer to retrieve POJOs (plain old Java objects) from a relational database. The tutorial demonstrates how wizards in the IDE can help you create the necessary Hibernate files and add Hibernate dependencies to the POM. After creating the Java objects and configuring the application to use Hibernate, you create a GUI interface for searching and displaying the data.
 
 Support for Maven is fully integrated in NetBeans IDE and Maven 3 is bundled with the IDE. You can create applications from the bundled Maven archetypes or from archetypes in remote repositories in the New Project wizard. The Maven Repository Browser enables you to explore your local and remote Maven repositories, examine artifacts and add project dependencies to the project's POM.
@@ -57,7 +55,7 @@ Before starting this tutorial you may want to familiarize yourself with the foll
 
 You can download link:https://netbeans.org/projects/samples/downloads/download/Samples/Java/DVDStoreAdmin-Maven.zip[+a zip archive of the finished project+].
 
-=== Creating the Database
+== Creating the Database
 
 This tutorial uses a MySQL database called  ``sakila`` . The sample database is not included when you install the IDE so you need to first create the database to follow this tutorial.
 
@@ -77,7 +75,7 @@ When you click OK the IDE will run a script to create the Sakila database and po
 
 When you click Connect, a database connection node for the Sakila database ( ``jdbc:mysql://localhost:3306/sakila [_username_ on Default]`` ) is listed under the Databases node. When a connection is open you can view the data in the database by expanding the connection node.
 
-=== Configuring Maven
+== Configuring Maven
 
 Maven is bundled with the IDE and installed when you install the IDE, but if this is your first Maven project you will want to check the Maven configuration settings in the Options window.
 
@@ -94,7 +92,7 @@ You can use the Maven version bundled with the IDE or specify the location of a 
 * Maven support is automatically enabled when Java is enabled in the IDE. You will need to enable the Java EE plugin if it is not enabled.
 * In NetBeans IDE 7.1 and earlier versions of the IDE, the Maven tab in the Options window is located in the Miscellaneous category.
 
-==== Viewing the Maven Repositories
+=== Viewing the Maven Repositories
 
 The artifacts that are used by Maven to build all your projects are stored in your local Maven repository. When an artifact is declared as a project dependency, the artifact is downloaded to your local repository from one of the registered remote repositories.
 
@@ -121,11 +119,11 @@ For more about managing Maven classpath dependencies and working with Maven repo
 * Choose Window > Other > Maven Repositories Browser to view Maven repositories.
 * You can use the buttons in the toolbar of the Maven Repositories Browser to update indexes and search for artifacts.
 
-=== Creating the Maven Application
+== Creating the Maven Application
 
 In this tutorial you create a simple Java Swing application project called DVDStoreAdmin. You will create the project from one of the bundled Maven archetypes and then modify the default project settings.
 
-==== Choosing an Archetype
+=== Choosing an Archetype
 
 The New Project wizard enables you to create a Maven project from a Maven archetype. The IDE includes several archetypes for common NetBeans project types, but you can also locate and choose archetypes in remote repositories in the wizard.
 
@@ -143,7 +141,7 @@ When you click finish the IDE creates the Maven project and opens the project in
 
 *Note.* If this is the first time you are creating a Maven project, Maven will need to download some necessary plugins and artifacts to the local repository. This can take some time.
 
-==== Modifying Project Properties
+=== Modifying Project Properties
 
 When you create a Maven project using the wizard, the default project properties are based on the archetype. In some cases, you may need to modify the default properties according to your system and the project's requirements. For example, for this project you want to confirm that the Source level is set to 1.5 or higher because the project uses annotations.
 
@@ -152,7 +150,7 @@ When you create a Maven project using the wizard, the default project properties
 3. Confirm that the Source/Binary Format that is selected in the drop-down list is 1.5 or higher.
 4. Select UTF-8 from the drop-down list for the Encoding property. Click OK.
 
-=== Adding Hibernate Files and Dependencies
+== Adding Hibernate Files and Dependencies
 
 To add support for Hibernate you need to make the Hibernate libraries available by declaring the necessary artifacts as dependencies in the POM. The IDE includes wizards to help you create the Hibernate files you may need in your project. You can use the wizards in the IDE to create a Hibernate configuration file and a utility helper class. If you create the Hibernate configuration file using a wizard the IDE automatically updates the POM to add the Hibernate dependencies to the project.
 
@@ -160,7 +158,7 @@ You can add dependencies to the project in the Projects window or by editing  ``
 
 To edit  ``pom.xml``  directly, open the file by expanding the Project Files node in the Projects window and double-clicking  ``pom.xml`` .
 
-==== Creating the Hibernate Configuration File
+=== Creating the Hibernate Configuration File
 
 The Hibernate configuration file ( ``hibernate.cfg.xml`` ) contains information about the database connection, resource mappings, and other connection properties. When you create a Hibernate configuration file using a wizard you specify the database connection by choosing from a list of database connection registered with the IDE. When generating the configuration file the IDE automatically adds the connection details and dialect information based on the selected database connection. The IDE also automatically modifies the POM to add the required Hibernate dependencies. After you create the configuration file you can edit the file using the multi-view editor, or edit the XML directly in the XML editor.
 
@@ -184,7 +182,7 @@ image::images/maven-artifacts-viewer.png[title="Graphs tab or Artifact Viewer sh
 
 You can also use the Graphs tab to discover and resolve version conflicts among dependencies.
 
-==== Modifying the Hibernate Configuration File
+=== Modifying the Hibernate Configuration File
 
 In this exercise you will edit the default properties specified in  ``hibernate.cfg.xml``  to enable debug logging for SQL statements. This exercise is optional.
 
@@ -222,7 +220,7 @@ If you click the XML tab in the editor you can see the file in XML view. Your fi
 
 When you run your project you will be able to see the SQL query printed in the IDE's Output window.
 
-==== Creating the  ``HibernateUtil.java``  Helper File
+=== Creating the  ``HibernateUtil.java``  Helper File
 
 To use Hibernate you need to create a helper class that handles startup and that accesses Hibernate's  ``SessionFactory``  to obtain a Session object. The class calls Hibernate's  ``configure()``  method, loads the  ``hibernate.cfg.xml``  configuration file and then builds the  ``SessionFactory``  to obtain the Session object.
 
@@ -235,7 +233,7 @@ image::images/maven-hibutil-wizard.png[title="Hibernate Util wizard"]
 
 When you click Finish,  ``HibernateUtil.java``  opens in the editor. You can close the file because you do not need to edit the file.
 
-=== Generating Hibernate Mapping Files and Java Classes
+== Generating Hibernate Mapping Files and Java Classes
 
 In this tutorial you use a plain old Java object (POJO),  ``Actor.java`` , to represent the data in the table ACTOR in the database. The class specifies the fields for the columns in the tables and uses simple setters and getters to retrieve and write the data. To map  ``Actor.java``  to the ACTOR table you can use a Hibernate mapping file or use annotations in the class.
 
@@ -243,7 +241,7 @@ You can use the Reverse Engineering wizard and the Hibernate Mapping Files and P
 
 *Note.* When you want to create files for multiple tables you will most likely want to use the wizards. In this tutorial you only need to create one POJO and one mapping file so it is fairly easy to create the files individually. You can see the steps for <<10,creating the POJOs and mapping files individually>> at the end of this tutorial.
 
-==== Create Reverse Engineering File
+=== Create Reverse Engineering File
 
 To use the POJOs and Mapping Files from Database wizard, you need to first create the  ``reveng.xml``  reverse engineering file in the  ``src/main/resources``  directory where you created  ``hibernate.cfg.xml`` .
 
@@ -257,7 +255,7 @@ The wizard generates a  ``hibernate.reveng.xml``  reverse engineering file. You 
 
 *Note.* This project requires a MySQL connector jar library ( ``mysql-connector-jar-5.1.13.jar`` , for example). If a suitable JAR is not listed as a project dependency under the Dependencies node, you can add the dependency by right-clicking the Dependencies node and choosing Add Dependency.
 
-==== Creating Hibernate Mapping Files and POJOs From a Database
+=== Creating Hibernate Mapping Files and POJOs From a Database
 
 The Hibernate Mapping Files and POJOs from a Database wizard generates files based on tables in a database. When you use the wizard, the IDE generates POJOs and mapping files for you based on the database tables specified in  ``hibernate.reveng.xml``  and then adds the mapping entries to  ``hibernate.cfg.xml`` . When you use the wizard you can choose the files that you want the IDE to generate (only the POJOs, for example) and select code generation options (generate code that uses EJB 3 annotations, for example).
 
@@ -273,13 +271,13 @@ When you click Finish, the IDE generates the POJO  ``Actor.java``  with all the 
 
 Now that you have the POJO and necessary Hibernate-related files you can create a simple Java GUI front end for the application. You will also create and then add an HQL query that queries the database to retrieve the data. In this process we also use the HQL editor to build and test the query.
 
-=== Creating the Application GUI
+== Creating the Application GUI
 
 In this exercise you will create a simple JFrame Form with some fields for entering and displaying data. You will also add a button that will trigger a database query to retrieve the data.
 
 If you are not familiar with using the GUI builder to create forms, you might want to review the link:gui-functionality.html[+Introduction to GUI Building+] tutorial.
 
-==== Creating the JFrame Form
+=== Creating the JFrame Form
 
 1. Right-click the project node in the Projects window and choose New > Other to open the New File wizard.
 2. Select JFrame Form from the Swing GUI Forms category. Click Next.
@@ -287,7 +285,7 @@ If you are not familiar with using the GUI builder to create forms, you might wa
 
 When you click Finish, the IDE creates the class and opens the JFrame Form in the Design view of the editor.
 
-==== Adding Elements to the Form
+=== Adding Elements to the Form
 
 You now need to add the UI elements to the form. When the form is open in Design view in the editor, the Palette appears in the right side of the IDE. To add an element to the form, drag the element from the Palette into the form area. After you add an element to the form you need to modify the default value of the Variable Name property for that element.
 
@@ -330,7 +328,7 @@ image::images/hib-jframe-form.png[title="GUI form in Design view of the editor"]
 
 Now that you have a form you need to create the code to assign events to the form elements. In the next exercise you will construct queries based on Hibernate Query Language to retrieve data. After you construct the queries you will add methods to the form to invoke the appropriate query when the Query button is pressed.
 
-=== Creating the Query in the HQL Query Editor
+== Creating the Query in the HQL Query Editor
 
 In the IDE you can construct and test queries based on the Hibernate Query Language (HQL) using the HQL Query Editor. As you type the query the editor shows the equivalent (translated) SQL query. When you click the 'Run HQL Query' button in the toolbar, the IDE executes the query and shows the results at the bottom of editor.
 
@@ -377,7 +375,7 @@ The query returns a list of actors' details for those actors whose last names be
 
 Testing the queries shows that the queries return the desired results. The next step is to implement the queries in the application so that the appropriate query is invoked by clicking the Query button in the form.
 
-=== Adding the Query to the Form
+== Adding the Query to the Form
 
 You now need to modify  ``DVDStoreAdmin.java``  to add the query strings and create the methods to construct and invoke a query that incorporates the input variables. You also need to modify the button event handler to invoke the correct query and add a method to display the query results in the table.
 
@@ -481,7 +479,7 @@ private void displayResult(List resultList) {
 
 After you save the form you can run the project.
 
-=== Running a Maven Project
+== Running a Maven Project
 
 Now that the coding is finished, you can build the project and launch the application. When you build a Maven project in the IDE, Maven reads the project's POM to identify the project dependencies. All the artifacts specified as dependencies must be in your local Maven repository in order to build the project. If a required artifact is not in the local repository, Maven will checkout the artifact from a remote repository before attempting to build and run the project. After building the project, Maven will install the resulting binary as an artifact in your local repository.
 
@@ -513,7 +511,7 @@ image::images/application-run.png[title="DVDStoreAdmin application showing resul
 
 If you look in the Output window of the IDE you can see the SQL query that retrieved the displayed results.
 
-==== Downloading the Solution Project
+=== Downloading the Solution Project
 
 You can download the solution to this tutorial as a project in the following ways.
 
@@ -537,7 +535,7 @@ When you click Finish, the IDE initializes the local folder as a Subversion repo
 * Steps for checking out sources from Kenai only apply to NetBeans IDE 6.7 and 6.8.
 * You need a Subversion client to checkout the sources from Kenai. For more about installing Subversion, see the section on link:../ide/subversion.html#settingUp[+Setting up Subversion+] in the link:../ide/subversion.html[+Guide to Subversion in NetBeans IDE+].
 
-=== Creating POJOs and Mapping Files Individually
+== Creating POJOs and Mapping Files Individually
 
 Because a POJO is a simple Java class you can use the New Java Class wizard to create the class and then edit the class in the source editor to add the necessary fields and getters and setters. After you create the POJO you then use a wizard to create a Hibernate mapping file to map the class to the table and add mapping information to  ``hibernate.cfg.xml`` . When you create a mapping file from scratch you need to map the fields to the columns in the XML editor.
 

--- a/netbeans.apache.org/src/content/kb/docs/java/profile-loadgenerator.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profile-loadgenerator.asciidoc
@@ -18,29 +18,23 @@
 //
 
 
-== Using a Load Generator in NetBeans IDE
+= Using a Load Generator in NetBeans IDE
+:jbake-type: tutorial
+:jbake-tags: tutorials 
+:jbake-status: published
+:syntax: true
+:source-highlighter: pygments
+:toc: left
+:toc-title:
+:description: Using a Load Generator in NetBeans IDE
+:keywords: Using a Load Generator in NetBeans IDE
 
 When testing the performance of an application, it can be beneficial to perform your tests under a typical load. This can be difficult if you are running your application in a development environment. One way to emulate an application running under load is through the use of a load generator script. This document presents an overview of load generator support offered by the IDE.
 
 Instead of supplying its own load generator runtime, the IDE relies on integrating third party tools. NetBeans IDE supports the Apache JMeter Load Testing Tool (link:http://jakarta.apache.org/jmeter[+homepage+]) to replay load testing scripts. To use the JMeter tool in the IDE, you first need to download the required plugins from the Update Center.
 
 
-=== Contents
-
-image::images/netbeans-stamp-80-74-73.png[title="Content on this page applies to the NetBeans IDE 7.2, 7.3, 7.4 and 8.0"]
-
-* <<Exercise_1,Installing the JMeter Plugins>>
-* <<Exercise_2,Working with the JMeter Load Testing Script>>
-* <<Exercise_2a,Creating a Load Testing Script>>
-* <<Exercise_2b,Editing a Load Testing Script>>
-* <<Exercise_2c,Starting a Load Testing Script>>
-* <<Exercise_2d,Stopping and Restarting a Load Testing Script>>
-
-
-== Getting Started
-
-
-=== Prerequisites
+== Prerequisites
 
 This document assumes you have some basic knowledge of, or programming experience with, the following technologies:
 
@@ -48,7 +42,7 @@ This document assumes you have some basic knowledge of, or programming experienc
 * NetBeans IDE
 
 
-=== Software Needed for the Tutorial
+== Software Needed for the Tutorial
 
 For this tutorial you need to have the following software installed on your computer:
 

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-intro.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-intro.asciidoc
@@ -29,8 +29,6 @@
 :description: Introduction to Profiling Java Applications in NetBeans IDE - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, Introduction to Profiling Java Applications in NetBeans IDE
 
-== Introduction to Profiling Java Applications in NetBeans IDE
-
 NetBeans IDE includes a powerful profiling tool that can provide important information about the runtime behavior of your application. The NetBeans profiling tool easily enables you to monitor thread states, CPU performance, and memory usage of your application from within the IDE, and imposes relatively low overhead.
 
 This introductory document is an overview of the profiling tools included in the IDE and a guide to help you quickly start profiling your NetBeans projects. This document is intended to demonstrate the various profiling tasks available in the IDE and the profiling results you can obtain when profiling a project. It does not cover all the profiling features included in the IDE, nor does it explore how to interpret profiling results to resolve specific performance issues you may have in your application.
@@ -45,11 +43,11 @@ This document shows how to use the IDE to profile the application and obtain the
 
 Additionally, this document demonstrates how to take and compare snapshots of profiling results.
 
-=== Profiling for the First Time
+== Profiling for the First Time
 
 The first time that you use the profiling tool, the IDE needs to perform some initial operations to ensure that accurate profile results are obtained and to integrate the tool with the project. To demonstrate this, you will first create the AnagramGame project and then run the calibration. The IDE will automatically perform the integration the first time you profile the AnagramGame project.
 
-==== Creating the Sample Project
+=== Creating the Sample Project
 
 In this document you will profile the Anagram Game sample application. To do this you will first use the New Project wizard to create the sample application and set the project as the Main Project.
 
@@ -66,7 +64,7 @@ When you click Finish, the IDE creates the Anagram Game sample project.
 
 After you set the project as the main project you can see that the name of the Anagram Game project is in bold in the Projects window. By default, when using the IDE to profile a project, the IDE will profile the main project. If no project is set as the main project the IDE will profile the project that is selected in the Projects window.
 
-==== Using the Profiler for the First Time
+=== Using the Profiler for the First Time
 
 To achieve accurate profiling results, you must have calibration data for each Java platform that will be used for profiling. If you are running the profiling tool for the first time, or if valid calibration data is unavailable for the Java platform, the IDE will prompt you to run the calibration process for your platform.
 
@@ -84,7 +82,7 @@ image::images/calibrate-information.png[title="Calibration Information dialog"]
 
 image::images/calibrate-select-platform.png[title="Dialog box to select the Java Platform when calibrating."]
 
-=== Selecting a Profiling Task
+== Selecting a Profiling Task
 
 The IDE provides a number of internal settings that let you tune profiling to your needs. For example, you may decrease the profiling overhead at the cost of some reduction in the amount of generated information. However, it may take some time to understand the meaning and use of the numerous settings available. For many applications, the default settings specified for the profiling tasks are sufficient in most situations.
 
@@ -102,7 +100,7 @@ When profiling a project, you use the Select Profiling Task dialog box to choose
 
 The Select Profiling Task dialog box is the main interface for running a profiling task. After you select a task, you can modify the task settings to fine tune the results you will obtain. For each of the profiling tasks, you can also create and save custom profiling tasks based on the task. When you create a custom profiling task, the custom task is listed in the Select Profiling Task dialog box so that you can easily find and run your custom settings later. When you create a custom profiling task, you can modify more advanced profiling settings by clicking *Advanced settings* in the Select Profiling Task dialog box.
 
-==== Monitoring an Application
+=== Monitoring an Application
 
 When you choose the Monitor task, the target application is started without any instrumentation. When monitoring an application, you obtain high-level information about several important properties of the target JVM. Because monitoring an application imposes very low overhead, you can run the application in this mode for extended periods of time.
 
@@ -133,7 +131,7 @@ image::images/profile-intro-telemoverview.png[title="Telemetry Overview window"]
 
 If the overview does not open automatically you can choose Window > Profiling > VM Telemetry Overview to open the overview in the Output window. You can open the VM Telemetry Overview window and see monitoring data at any time during any profiling session.
 
-==== Analyzing CPU Performance
+=== Analyzing CPU Performance
 
 When you choose the CPU task, the IDE profiles the method-level CPU performance (execution time) of your application and processes the results in real-time. You can choose to analyze the performance by periodically taking a stack trace or by instrumenting the methods in the application. You can choose to instrument all the methods or limit the instrumentation to a part of the application code, even down to a specific code fragment.
 
@@ -185,7 +183,7 @@ image::images/cpu-liveresults1.png[title="CPU Live Results"]
 
 You can quickly navigate to the source code containing any of the listed methods by right-clicking the name of the method and choosing Go To Source. When you click Go To Source the class opens in the Source editor.
 
-==== Analyzing Memory Usage
+=== Analyzing Memory Usage
 
 The Analyze Memory Usage task gives you data on objects that have been allocated in the target application such as the number, type and location of the allocated objects.
 
@@ -220,7 +218,7 @@ By default the results are sorted and displayed by the number of Live Bytes, but
 
 image::images/profile-java-memresults1.png[title="Memory Profiling Results"]
 
-=== Taking Snapshots
+== Taking Snapshots
 
 When a profiling session is in progress, you can capture profiling results by taking a snapshot. A snapshot captures the profiling data at the moment you take the snapshot. However, snapshots differ from live profiling results in the following ways:
 
@@ -230,7 +228,7 @@ When a profiling session is in progress, you can capture profiling results by ta
 
 Because a profiling session does not have to be in progress to open a project's snapshots, you can open a project's snapshot at any time by selecting the snapshot in the list of saved snapshots in the Profiler window and clicking Open.
 
-==== Taking and Comparing Memory Snapshots
+=== Taking and Comparing Memory Snapshots
 
 For the Anagram Game application, you can take a snapshot of the results to see the allocation stack trace for the objects of type  ``String`` . You can then take another snapshot and compare the two. By comparing memory snapshots you can see what objects have been created or released from the heap in the interval between when you took the two snapshots. The snapshots must be comparable, which means that the profiling type (e.g., Allocations vs. Liveness) and the number of tracked objects must match.
 
@@ -265,7 +263,7 @@ The snapshot comparison looks similar to a memory snapshot but only displays the
 
 *Note.* You can also set Take Snapshot profiling points for more precise control over when snapshots are taken. For more on how to take snapshots using profiling points, see link:../../docs/java/profiler-profilingpoints.html[+Using Profiling Points in NetBeans IDE+].
 
-=== Conclusion
+== Conclusion
 
 This concludes the introduction to profiling an application using NetBeans IDE. This document demonstrated the basics of how to use the IDE to profile a simple NetBeans project and view the profiling results. The steps outlined above can be applied when profiling most projects. Profiling more complex projects such as enterprise applications and free-form projects may require additional configuration steps.
 

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend.asciidoc
@@ -31,23 +31,9 @@
 This document describes visual feedback the IDE's GUI Builder (formerly code-named Matisse) provides during the process of Java GUI creation.
 
 
-=== Contents
-
-image::images/netbeans-stamp-80-74-73.png[title="Content on this page applies to NetBeans IDE 6.9 and more recent"]
-
-* <<alignment,Alignment Guidelines>>
-* <<anchor,Anchoring Indicators>>
-* <<size,Sizing Indicators>>
-* <<highlight,Highlighting and Handles>>
-* <<seealso,See Also>>
-[quote]
-----
-
-
 == Alignment Guidelines
 
 Alignment guidelines appear only when adding or moving components, indicating the preferred positions to which components snap when the mouse button is released. Once positioned, alignment guidelines are replaced by solid lines illustrating the common alignments shared among components as well as anchoring indicators.
-
 
 |===
 |*Inset* |image::images/legend5.png[] |Insets are the preferred spacings between components and the containers within which they are located. Insets are suggested by dashed horizontal and vertical guidelines. 

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui.asciidoc
@@ -38,34 +38,9 @@ In this tutorial you will learn how to: use the GUI Builder Interface, create a 
 This tutorial takes about 30 minutes to complete.
 
 
-=== Contents
+== Requirements
 
-* <<getting_started,Getting Started>>
-* <<project,Creating a Project>>
-* <<container,Creating a JFrame Container>>
-* <<getting_familiar,Getting Familiar with the GUI Builder>>
-* <<key_concepts,Key Concepts>>
-* <<design,Free Design>>
-* <<snapping,Automatic Component Positioning (Snapping)>>
-* <<feedback,Visual Feedback>>
-* <<first_things,First Things First>>
-* <<adding_components,Adding Components: The Basics>>
-* <<individual,Adding Individual Components to the Form>>
-* <<multiple,Adding Multiple Components to the Form>>
-* <<inserting,Inserting Components>>
-* <<moving_forward,Moving Forward>>
-* <<aligning_components,Component Alignment>>
-* <<baseline_alignment,Baseline Alignment>>
-* <<reviewing,Reviewing What We've Learned>>
-* <<adding_aligning_anchoring,Adding, Aligning, and Anchoring>>
-* <<component_sizing,Component Sizing>>
-* <<indentation,Indentation>>
-* <<adjusting_form,Making the Final Adjustments>>
-* <<previewing_form,Previewing Your GUI>>
-* <<deploying,Deploying GUI Applications>>
-* <<seealso,See Also>>
-
-*To complete this tutorial, you need the following software and resources.*
+To complete this tutorial, you need the following software and resources.
 
 |===
 |Software or Resource |Version Required 

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart.asciidoc
@@ -17,7 +17,7 @@
 //     under the License.
 //
 
-= NetBeans IDE Java Quick Start Tutorial
+= Java Quick Start Tutorial
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
@@ -30,7 +30,6 @@
 :description: NetBeans IDE Java Quick Start Tutorial - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials, NetBeans IDE Java Quick Start Tutorial
 
-= Java Quick Start Tutorial
 
 Welcome to Apache NetBeans IDE!
 

--- a/netbeans.apache.org/src/content/templates/tutorial.gsp
+++ b/netbeans.apache.org/src/content/templates/tutorial.gsp
@@ -27,6 +27,7 @@
         <%include "menu.gsp"%>
         <%include "news.gsp"%>
         <div class='grid-container main-content tutorial'>
+            <h1 class="sect0">${content.title}</h1>
             ${content.body}
             <%include "tools.gsp"%>
         </div>


### PR DESCRIPTION
Now tutorials use asciidoc level0.
This makes it easier to create ePub books, but requires reviewing some tutorials.
Examples of use:
/kb/docs/java/index.asciidoc
/kb/docs/java/quickstart.asciidoc

Basically:
- One level 0 header at the top of the document "= Whatever the title"
- The rest of headers start at level 1 "== " or greater.
