### PR TITLE
[NETBEANS-1867] Tutorials: jira tickets, green checkmark, icons

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/cnd.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -53,6 +55,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -79,6 +82,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -98,6 +102,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -116,6 +121,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/HowTos.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/HowTos.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/HowTos_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/HowTos_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/HowTos_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/HowTos_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/HowTos_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/HowTos_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/HowTos_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/HowTos_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/beginning-jni-linux.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/beginning-jni-linux.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/beginning-jni-linux_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/beginning-jni-linux_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/beginning-jni-linux_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/beginning-jni-linux_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/beginning-jni-linux_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/beginning-jni-linux_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/beginning-jni-linux_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/beginning-jni-linux_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/c-unit-test_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/cpp-vcs.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/cpp-vcs.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/cpp-vcs_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/cpp-vcs_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/cpp-vcs_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/cpp-vcs_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/cpp-vcs_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/cpp-vcs_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/cpp-vcs_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/cpp-vcs_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/debugging.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/debugging.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/debugging_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/debugging_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/debugging_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/debugging_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/debugging_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/debugging_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/debugging_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/debugging_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/depchecking.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/depchecking.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/depchecking_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/depchecking_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/depchecking_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/depchecking_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/depchecking_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/depchecking_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/depchecking_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/depchecking_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/development-environment.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/development-environment.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/development-environment_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/development-environment_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/development-environment_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/development-environment_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/development-environment_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/development-environment_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/development-environment_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/development-environment_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/index.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/index.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: C and C++ Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/cnd/index_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/index_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: C and C++ Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/cnd/index_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/index_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: C and C++ Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/cnd/index_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/index_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: C and C++ Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/cnd/index_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/index_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: C and C++ Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/cnd/navigating-editing.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/navigating-editing.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/navigating-editing_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/navigating-editing_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/navigating-editing_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/navigating-editing_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/navigating-editing_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/navigating-editing_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/navigating-editing_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/navigating-editing_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/quickstart.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/quickstart.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/quickstart_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/quickstart_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/quickstart_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/quickstart_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/quickstart_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/quickstart_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/quickstart_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/quickstart_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/remote-modes.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/remote-modes.asciidoc
@@ -23,6 +23,7 @@ image::images/netbeans-stamp-80-74-73.png[title="Content on this page applies to
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/remote-modes_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/remote-modes_ja.asciidoc
@@ -23,6 +23,7 @@ image::images/netbeans-stamp-80-74-73.png[title="このページの内容は、N
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/remote-modes_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/remote-modes_pt_BR.asciidoc
@@ -23,6 +23,7 @@ image::images/netbeans-stamp-80-74-73.png[title="O conteúdo desta página se ap
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/remote-modes_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/remote-modes_ru.asciidoc
@@ -23,6 +23,7 @@ image::images/netbeans-stamp-80-74-73.png[title="Содержимое этой �
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/remote-modes_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/remote-modes_zh_CN.asciidoc
@@ -23,6 +23,7 @@ image::images/netbeans-stamp-80-74-73.png[title="此页上的内容适用于 Net
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/remotedev-tutorial_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/toolchain.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/toolchain.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/toolchain_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/toolchain_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/toolchain_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/toolchain_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/toolchain_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/toolchain_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd/toolchain_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd/toolchain_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -41,6 +42,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -55,6 +57,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -85,6 +88,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -103,6 +107,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -53,6 +55,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -79,6 +82,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -98,6 +102,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -116,6 +121,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -53,6 +55,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -79,6 +82,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -98,6 +102,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -116,6 +121,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -53,6 +55,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -79,6 +82,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -98,6 +102,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -116,6 +121,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/cnd_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/cnd_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -53,6 +55,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -79,6 +82,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -98,6 +102,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -116,6 +121,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/NetBeans_DTrace_GUI_Plugin_0_4.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/NetBeans_DTrace_GUI_Plugin_0_4.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/clearcase_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/clearcase_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/clearcase_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/clearcase_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/clearcase_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/clearcase_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/clearcase_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/clearcase_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/cvs_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/cvs_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/cvs_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/cvs_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/cvs_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/cvs_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/cvs_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/cvs_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/database-improvements-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/database-improvements-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/database-improvements-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/database-improvements-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/database-improvements-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/database-improvements-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/database-improvements-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/database-improvements-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/database-improvements-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/database-improvements-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/git_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/git_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/git_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/git_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/git_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/git_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/git_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/git_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/github_nb_screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/github_nb_screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/github_nb_screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/github_nb_screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/github_nb_screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/github_nb_screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/github_nb_screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/github_nb_screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/github_nb_screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/github_nb_screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/index.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/index.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: NetBeans IDE Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/ide/index_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/index_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: NetBeans IDE Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/ide/index_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/index_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: NetBeans IDE Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/ide/index_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/index_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: NetBeans IDE Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/ide/index_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/index_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: NetBeans IDE Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/ide/install-and-configure-mysql-server_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/install-and-configure-mysql-server_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/install-and-configure-mysql-server_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/install-and-configure-mysql-server_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/install-and-configure-mysql-server_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/install-and-configure-mysql-server_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/install-and-configure-mysql-server_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/install-and-configure-mysql-server_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/java-db.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/java-db.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/java-db_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/java-db_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/java-db_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/java-db_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/java-db_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/java-db_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/java-db_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/java-db_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/macro-keywords.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/macro-keywords.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mercurial-queues_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mercurial-queues_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mercurial-queues_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mercurial-queues_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mercurial-queues_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mercurial-queues_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mercurial-queues_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mercurial-queues_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mercurial_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mercurial_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mercurial_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mercurial_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mercurial_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mercurial_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mercurial_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mercurial_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mysql_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mysql_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mysql_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mysql_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mysql_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mysql_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/mysql_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/mysql_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/nb65-intro-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/nb65-intro-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/oracle-db_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/oracle-db_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/oracle-db_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/oracle-db_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/oracle-db_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/oracle-db_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/oracle-db_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/oracle-db_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast-smaller.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast-smaller.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast_731.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast_731.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/overview-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/platform-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/platform-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/platform-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/platform-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/platform-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/platform-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/platform-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/platform-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/platform-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/platform-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/subversion_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/subversion_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/subversion_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/subversion_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/subversion_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/subversion_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/subversion_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/subversion_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/team-servers.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/team-servers.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/team-servers_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/team-servers_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/team-servers_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/team-servers_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/team-servers_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/team-servers_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/ide/team-servers_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/ide/team-servers_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/index_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/index_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: NetBeans Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/index_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/index_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: NetBeans Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/index_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/index_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: NetBeans Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/index_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/index_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: NetBeans Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/index_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/index_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: NetBeans Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/intro-screencasts.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/intro-screencasts.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/intro-screencasts_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/intro-screencasts_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/intro-screencasts_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/intro-screencasts_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/intro-screencasts_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/intro-screencasts_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/intro-screencasts_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/intro-screencasts_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-ee.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-ee.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -58,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -76,6 +78,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -156,6 +159,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -198,6 +202,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="../docs/screenca
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -218,6 +223,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="../samples/index
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -242,6 +248,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="http://wiki.netb
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-ee_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-ee_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -50,6 +51,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -68,6 +70,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -135,6 +138,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -171,6 +175,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="../docs/screenca
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -191,6 +196,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="../samples/index
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -214,6 +220,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="http://wiki.netb
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-ee_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-ee_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -58,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -76,6 +78,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -155,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -197,6 +201,7 @@ image::../../images_www/v6/arrow-button.gif[role="left", link="../docs/screencas
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -217,6 +222,7 @@ image::../../images_www/v6/arrow-button.gif[role="left", link="../samples/index.
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -241,6 +247,7 @@ image::../../images_www/v6/arrow-button.gif[role="left", link="http://wiki.netbe
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-ee_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-ee_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -58,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -76,6 +78,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -155,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -197,6 +201,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="../docs/screenca
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -217,6 +222,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="../samples/index
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -241,6 +247,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="http://wiki.netb
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-ee_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-ee_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -58,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -76,6 +78,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -155,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -197,6 +201,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="../docs/screenca
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -217,6 +222,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="../samples/index
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -241,6 +247,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="http://wiki.netb
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-ee_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-ee_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -58,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -76,6 +78,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -155,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -197,6 +201,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="../docs/screenca
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -211,6 +216,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="../samples/index
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -235,6 +241,7 @@ image:::../../images_www/v6/arrow-button.gif[role="left", link="http://wiki.netb
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-se.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-se.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -41,6 +42,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -108,6 +111,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -134,6 +138,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -155,6 +160,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-se_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-se_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -41,6 +42,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -55,6 +57,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -105,6 +108,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -127,6 +131,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -150,6 +155,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-se_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-se_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -41,6 +42,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -55,6 +57,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -106,6 +109,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -132,6 +136,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -153,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-se_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-se_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -41,6 +42,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -55,6 +57,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -106,6 +109,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -132,6 +136,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -153,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-se_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-se_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -41,6 +42,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -55,6 +57,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -106,6 +109,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -132,6 +136,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -153,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java-se_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java-se_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -41,6 +42,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -55,6 +57,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -106,6 +109,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -132,6 +136,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -153,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations-custom.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations-custom.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations-custom_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations-custom_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations-custom_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations-custom_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations-custom_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations-custom_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations-custom_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations-custom_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations-lombok.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations-lombok.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations-lombok_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations-lombok_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations-lombok_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations-lombok_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations-lombok_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations-lombok_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations-lombok_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations-lombok_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/annotations_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/annotations_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/code-inspect_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/code-inspect_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-deadlock-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-deadlock-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-deadlock-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-deadlock-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-deadlock-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-deadlock-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-deadlock-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-deadlock-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-deadlock-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-deadlock-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-evaluator-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-evaluator-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-evaluator-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-evaluator-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-evaluator-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-evaluator-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-evaluator-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-evaluator-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-evaluator-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-evaluator-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-multithreaded_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-stepinto-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-stepinto-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-stepinto-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-stepinto-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-stepinto-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-stepinto-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-stepinto-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-stepinto-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-stepinto-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-stepinto-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-visual-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-visual-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-visual.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-visual.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-visual_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-visual_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-visual_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-visual_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-visual_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-visual_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/debug-visual_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/debug-visual_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/editor-formatting-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-formatting-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/editor-formatting-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-formatting-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/editor-formatting-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-formatting-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/editor-formatting-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-formatting-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/editor-formatting-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-formatting-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/editor-inspect-transform_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-inspect-transform_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/editor-inspect-transform_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-inspect-transform_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/editor-inspect-transform_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-inspect-transform_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/editor-inspect-transform_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-inspect-transform_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-advanced_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-advanced_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-advanced_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-advanced_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-advanced_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-advanced_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-advanced_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-advanced_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-basic_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-basic_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-basic_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-basic_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-basic_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-basic_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-basic_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gbcustomizer-basic_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/groovy-quickstart_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-automatic-i18n_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-automatic-i18n_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-automatic-i18n_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-automatic-i18n_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-automatic-i18n_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-automatic-i18n_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-automatic-i18n_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-automatic-i18n_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-binding_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-binding_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-binding_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-binding_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-binding_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-binding_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-binding_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-binding_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-builder-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-builder-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-builder-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-builder-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-builder-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-builder-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-builder-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-builder-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-builder-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-builder-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-filechooser_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-filechooser_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-filechooser_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-filechooser_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-filechooser_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-filechooser_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-filechooser_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-filechooser_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-functionality_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-functionality_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-functionality_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-functionality_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-functionality_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-functionality_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-functionality_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-functionality_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-gaps_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-gaps_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-gaps_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-gaps_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-gaps_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-gaps_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-gaps_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-gaps_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-image-display_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-image-display_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-image-display_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-image-display_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-image-display_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-image-display_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/gui-image-display_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/gui-image-display_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/hibernate-java-se_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/hibernate-java-se_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/hibernate-java-se_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/hibernate-java-se_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/hibernate-java-se_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/hibernate-java-se_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/hibernate-java-se_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/hibernate-java-se_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/import-eclipse.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/import-eclipse.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/index.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/index.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Java Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/java/index_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/index_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Java Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/java/index_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/index_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Java Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/java/index_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/index_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Java Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/java/index_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/index_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Java Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/java/index_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/index_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Java Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/java/introduce-refactoring-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/introduce-refactoring-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/introduce-refactoring-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/introduce-refactoring-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/introduce-refactoring-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/introduce-refactoring-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/introduce-refactoring-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/introduce-refactoring-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/introduce-refactoring-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/introduce-refactoring-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/java-editor-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/java-editor-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/java-editor-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/java-editor-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/java-editor-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/java-editor-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/java-editor-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/java-editor-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/java-editor-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/java-editor-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-deploy_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-deploy_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-deploy_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-deploy_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-deploy_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-deploy_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-deploy_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-deploy_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-embedded_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-embedded_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-embedded_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-embedded_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-embedded_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-embedded_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-embedded_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-embedded_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-intro_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-intro_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-intro_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-intro_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-intro_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-intro_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-intro_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-intro_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-jdk7.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-jdk7.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-jdk7_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-jdk7_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-jdk7_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-jdk7_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-jdk7_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-jdk7_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-jdk7_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-jdk7_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-jdk8_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-jdk8_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-jdk8_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-jdk8_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-jdk8_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-jdk8_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/javase-jdk8_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/javase-jdk8_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk7-nb70-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk7-nb70-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk7-nb70-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk7-nb70-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk7-nb70-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk7-nb70-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk7-nb70-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk7-nb70-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk7-nb70-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk7-nb70-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk8-migration-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk8-migration-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk8-migration-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk8-migration-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk8-migration-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk8-migration-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk8-migration-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk8-migration-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk8-migration-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk8-migration-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk8-nb74-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk8-nb74-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk8-nb74-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk8-nb74-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk8-nb74-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk8-nb74-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk8-nb74-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk8-nb74-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jdk8-nb74-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jdk8-nb74-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-getstart_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-getstart_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-getstart_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-getstart_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-getstart_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-getstart_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-getstart_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-getstart_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-manager-tutorial.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-manager-tutorial.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-manager-tutorial_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-manager-tutorial_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-manager-tutorial_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-manager-tutorial_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-manager-tutorial_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-manager-tutorial_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-manager-tutorial_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-manager-tutorial_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-tutorial.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-tutorial.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-tutorial_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-tutorial_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-tutorial_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-tutorial_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-tutorial_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-tutorial_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/jmx-tutorial_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/jmx-tutorial_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/junit-intro.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/junit-intro.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/junit-intro_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/junit-intro_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/junit-intro_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/junit-intro_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/junit-intro_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/junit-intro_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/junit-intro_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/junit-intro_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/maven-hib-java-se_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/maven-hib-java-se_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/maven-hib-java-se_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/maven-hib-java-se_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/maven-hib-java-se_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/maven-hib-java-se_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/maven-hib-java-se_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/maven-hib-java-se_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/native_pkg_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/native_pkg_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/native_pkg_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/native_pkg_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/native_pkg_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/native_pkg_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/native_pkg_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/native_pkg_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/nb_fx_screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/nb_fx_screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/nb_fx_screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/nb_fx_screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/nb_fx_screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/nb_fx_screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/nb_fx_screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/nb_fx_screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/nb_fx_screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/nb_fx_screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profile-loadgenerator.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profile-loadgenerator.asciidoc
@@ -22,6 +22,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-intro_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-intro_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-intro_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-intro_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-intro_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-intro_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-intro_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-intro_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-profilingpoints.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-profilingpoints.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-profilingpoints_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-profilingpoints_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-profilingpoints_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-profilingpoints_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-profilingpoints_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-profilingpoints_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-profilingpoints_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-profilingpoints_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/profiler-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/profiler-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/project-setup.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/project-setup.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui-legend_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart-gui_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/quickstart_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/quickstart_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/refactoring-nb71-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/refactoring-nb71-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/refactoring-nb71-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/refactoring-nb71-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/refactoring-nb71-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/refactoring-nb71-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/refactoring-nb71-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/refactoring-nb71-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/refactoring-nb71-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/refactoring-nb71-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/testng-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/testng-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/testng-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/testng-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/testng-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/testng-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/testng-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/testng-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/java/testng-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/testng-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-events.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-events.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-events_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-events_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-events_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-events_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-events_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-events_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-events_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-events_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-inject.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-inject.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-inject_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-inject_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-inject_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-inject_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-inject_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-inject_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-inject_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-inject_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-intro.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-intro.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-intro_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-intro_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-intro_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-intro_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-intro_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-intro_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-intro_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-intro_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-validate.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-validate.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-validate_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-validate_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-validate_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-validate_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-validate_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-validate_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/cdi-validate_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/cdi-validate_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/conclusion.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/conclusion.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/conclusion_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/conclusion_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/connect-db.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/connect-db.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/connect-db_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/connect-db_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/data-model.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/data-model.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/data-model_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/data-model_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/design.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/design.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/design_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/design_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/entity-session.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/entity-session.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/entity-session_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/entity-session_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/entity-session_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/entity-session_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/entity-session_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/entity-session_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/entity-session_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/entity-session_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/index.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/index.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: e-Commerce Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/index_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/index_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: e-Commerce Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/index_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/index_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: e-Commerce Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/index_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/index_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: e-Commerce Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/index_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/index_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: e-Commerce Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/intro.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/intro.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/intro_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/intro_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/intro_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/intro_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/intro_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/intro_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/intro_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/intro_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/language.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/language.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/language_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/language_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/manage-sessions.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/manage-sessions.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/manage-sessions_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/manage-sessions_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/manage-sessions_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/manage-sessions_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/manage-sessions_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/manage-sessions_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/manage-sessions_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/manage-sessions_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/netbeans-ecommerce-tutorial.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/netbeans-ecommerce-tutorial.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -326,6 +327,7 @@ link:/about/contact_form.html?to=3&subject=Feedback: NetBeans E-commerce Tutoria
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -712,6 +714,7 @@ link:/about/contact_form.html?to=3&subject=Feedback: NetBeans E-commerce Tutoria
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -1093,6 +1096,7 @@ link:/about/contact_form.html?to=3&subject=Feedback: NetBeans E-commerce Tutoria
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -1552,6 +1556,7 @@ link:/about/contact_form.html?to=3&subject=Feedback: NetBeans E-commerce Tutoria
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -2491,6 +2496,7 @@ link:/about/contact_form.html?to=3&subject=Feedback: NetBeans E-commerce Tutoria
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -3424,6 +3430,7 @@ This can occur when you are using an incorrect username/password combination. Ma
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -4092,6 +4099,7 @@ link:/about/contact_form.html?to=3&subject=Feedback: NetBeans E-commerce Tutoria
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -4945,6 +4953,7 @@ link:/about/contact_form.html?to=3&subject=Feedback: NetBeans E-commerce Tutoria
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -5870,6 +5879,7 @@ link:/about/contact_form.html?to=3&subject=Feedback: NetBeans E-commerce Tutoria
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -6840,6 +6850,7 @@ link:/about/contact_form.html?to=3&subject=Feedback: NetBeans E-commerce Tutoria
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -7606,6 +7617,7 @@ image::images/http-404.png[title="The browser address bar indicates that a secur
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -8271,6 +8283,7 @@ link:/about/contact_form.html?to=3&subject=Feedback: NetBeans E-commerce Tutoria
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -8585,6 +8598,7 @@ The sample application and project snapshots are provided "AS IS," without a war
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/page-views-controller.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/page-views-controller.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/page-views-controller_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/page-views-controller_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/page-views-controller_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/page-views-controller_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/page-views-controller_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/page-views-controller_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/page-views-controller_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/page-views-controller_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/security.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/security.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup-dev-environ.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup-dev-environ.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup-dev-environ_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup-dev-environ_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup-dev-environ_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup-dev-environ_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup-dev-environ_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup-dev-environ_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup-dev-environ_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup-dev-environ_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/setup_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/test-profile.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/test-profile.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/transaction.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/transaction.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/transaction_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/ecommerce/transaction_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/entappclient.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/entappclient.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/entappclient_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/entappclient_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/entappclient_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/entappclient_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/entappclient_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/entappclient_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/entappclient_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/entappclient_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/index.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/index.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: JavaEE Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javaee/index_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/index_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: JavaEE Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javaee/index_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/index_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: JavaEE Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javaee/index_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/index_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: JavaEE Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javaee/index_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/index_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: JavaEE Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javaee/index_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/index_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: JavaEE Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-ejb_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-ejb_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-ejb_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-ejb_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-ejb_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-ejb_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-ejb_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-ejb_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-junit.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-junit.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-junit_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-junit_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-junit_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-junit_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-junit_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-junit_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-junit_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-entapp-junit_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-js-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-js-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-pf-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-pf-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-gettingstarted_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-intro.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-intro.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-intro_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-intro_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-intro_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-intro_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-intro_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-intro_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/javaee-intro_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/javaee-intro_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/jpa-eclipselink-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/jpa-eclipselink-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/jpa-eclipselink-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/jpa-eclipselink-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/jpa-eclipselink-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/jpa-eclipselink-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/jpa-eclipselink-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/jpa-eclipselink-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/jpa-eclipselink-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/jpa-eclipselink-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp-testing.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp-testing.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp-testing_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp-testing_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp-testing_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp-testing_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp-testing_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp-testing_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp-testing_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp-testing_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-entapp_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-osgiservice-cdi.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-osgiservice-cdi.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-osgiservice-cdi_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-osgiservice-cdi_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-osgiservice-cdi_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-osgiservice-cdi_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-osgiservice-cdi_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-osgiservice-cdi_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-osgiservice-cdi_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-osgiservice-cdi_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-primefaces-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-primefaces-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-primefaces-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-primefaces-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-primefaces-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-primefaces-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-primefaces-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-primefaces-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-primefaces-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-primefaces-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/maven-websocketapi_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/profiler-javaee_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/profiler-javaee_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/profiler-javaee_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/profiler-javaee_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/profiler-javaee_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/profiler-javaee_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/profiler-javaee_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/profiler-javaee_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/secure-ejb.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/secure-ejb.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/secure-ejb_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/secure-ejb_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/secure-ejb_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/secure-ejb_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/secure-ejb_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/secure-ejb_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/secure-ejb_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/secure-ejb_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/weblogic-javaee-m1-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/weblogic-javaee-m1-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/weblogic-javaee-m1-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/weblogic-javaee-m1-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/weblogic-javaee-m1-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/weblogic-javaee-m1-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/weblogic-javaee-m1-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/weblogic-javaee-m1-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javaee/weblogic-javaee-m1-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javaee/weblogic-javaee-m1-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/imp-ng_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/imp-ng_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/imp-ng_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/imp-ng_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/imp-ng_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/imp-ng_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/imp-ng_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/imp-ng_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/index.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/index.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: JavaME Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javame/index_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/index_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: JavaME Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javame/index_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/index_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: JavaME Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javame/index_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/index_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: JavaME Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javame/index_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/index_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: JavaME Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/javame/java-card_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/java-card_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/java-card_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/java-card_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/java-card_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/java-card_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/java-card_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/java-card_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/javacard_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/javacard_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/javacard_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/javacard_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/javacard_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/javacard_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/javacard_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/javacard_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/nb_me8_screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/nb_me8_screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/nb_me8_screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/nb_me8_screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/nb_me8_screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/nb_me8_screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/javame/nb_me8_screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/javame/nb_me8_screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/matisse.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/matisse.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -124,6 +127,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -159,6 +163,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -179,6 +184,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -198,6 +204,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/matisse_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/matisse_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -89,6 +92,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -106,6 +110,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -127,6 +132,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/matisse_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/matisse_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -124,6 +127,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -159,6 +163,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -179,6 +184,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -198,6 +204,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/matisse_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/matisse_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -91,6 +94,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -126,6 +130,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -146,6 +151,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -165,6 +171,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/matisse_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/matisse_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -124,6 +127,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -159,6 +163,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -179,6 +184,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -198,6 +204,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/matisse_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/matisse_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -124,6 +127,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -159,6 +163,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -179,6 +184,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -198,6 +204,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/mobility.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/mobility.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -54,6 +56,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -72,6 +75,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -91,6 +95,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -109,6 +114,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/mobility_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/mobility_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -44,6 +45,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -59,6 +61,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -110,6 +113,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -127,6 +131,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -152,6 +157,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -170,6 +176,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/mobility_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/mobility_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -54,6 +56,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -72,6 +75,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -92,6 +96,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -110,6 +115,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/mobility_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/mobility_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -54,6 +56,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -72,6 +75,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -92,6 +96,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -110,6 +115,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/mobility_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/mobility_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -54,6 +56,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -72,6 +75,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -92,6 +96,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -110,6 +115,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/mobility_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/mobility_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -54,6 +56,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -72,6 +75,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -92,6 +96,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -110,6 +115,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -36,6 +37,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -55,6 +57,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -142,6 +145,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -176,6 +180,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -195,6 +200,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/ajax-quickstart_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/ajax-quickstart_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/ajax-quickstart_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/ajax-quickstart_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/ajax-quickstart_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/ajax-quickstart_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/ajax-quickstart_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/ajax-quickstart_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/code-templates_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/code-templates_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/code-templates_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/code-templates_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/code-templates_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/code-templates_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/code-templates_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/code-templates_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-mac-os.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-mac-os.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-mac-os_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-mac-os_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-mac-os_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-mac-os_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-mac-os_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-mac-os_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-mac-os_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-mac-os_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-ubuntu_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-ubuntu_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-ubuntu_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-ubuntu_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-ubuntu_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-ubuntu_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-ubuntu_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-ubuntu_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-windows_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-windows_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-windows_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-windows_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-windows_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-windows_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-windows_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/configure-php-environment-windows_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/debugging_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/debugging_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/debugging_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/debugging_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/debugging_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/debugging_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/debugging_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/debugging_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/editor-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/editor-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/editor-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/editor-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/editor-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/editor-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/editor-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/editor-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/editor-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/editor-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/flickr-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/flickr-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/flickr-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/flickr-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/flickr-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/flickr-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/flickr-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/flickr-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/flickr-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/flickr-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/index.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/index.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: PHP Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/php/index_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/index_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: PHP Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/php/index_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/index_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: PHP Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/php/index_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/index_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: PHP Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/php/index_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/index_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: PHP Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/php/namespace-code-completion-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/namespace-code-completion-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/namespace-code-completion-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/namespace-code-completion-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/namespace-code-completion-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/namespace-code-completion-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/namespace-code-completion-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/namespace-code-completion-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/namespace-code-completion-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/namespace-code-completion-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/php-editor-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/php-editor-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/php-editor-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/php-editor-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/php-editor-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/php-editor-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/php-editor-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/php-editor-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/php-editor-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/php-editor-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/php-variables-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/php-variables-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/php-variables-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/php-variables-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/php-variables-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/php-variables-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/php-variables-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/php-variables-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/php-variables-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/php-variables-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/phpunit_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/phpunit_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/phpunit_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/phpunit_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/phpunit_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/phpunit_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/phpunit_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/phpunit_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/project-config-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/project-config-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/project-config-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/project-config-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/project-config-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/project-config-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/project-config-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/project-config-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/project-config-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/project-config-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/project-setup_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/project-setup_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/project-setup_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/project-setup_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/project-setup_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/project-setup_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/project-setup_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/project-setup_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/quickstart_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/quickstart_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/quickstart_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/quickstart_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/quickstart_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/quickstart_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/quickstart_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/quickstart_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/remote-hosting-and-ftp-account_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/remote-hosting-and-ftp-account_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/remote-hosting-and-ftp-account_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/remote-hosting-and-ftp-account_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/remote-hosting-and-ftp-account_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/remote-hosting-and-ftp-account_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/remote-hosting-and-ftp-account_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/remote-hosting-and-ftp-account_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-continuous-builds.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-continuous-builds.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-continuous-builds_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-continuous-builds_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-continuous-builds_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-continuous-builds_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-continuous-builds_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-continuous-builds_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-continuous-builds_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-continuous-builds_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-doctrine2.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-doctrine2.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-php54.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-php54.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-phpdoc.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-phpdoc.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-phpdoc_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-phpdoc_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-phpdoc_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-phpdoc_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-phpdoc_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-phpdoc_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-phpdoc_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-phpdoc_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-rename-refactoring.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-rename-refactoring.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-rename-refactoring_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-rename-refactoring_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-rename-refactoring_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-rename-refactoring_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-rename-refactoring_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-rename-refactoring_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-rename-refactoring_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-rename-refactoring_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-smarty.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-smarty.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-smarty_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-smarty_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-smarty_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-smarty_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-smarty_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-smarty_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/screencast-smarty_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/screencast-smarty_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson1_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson1_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson1_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson1_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson1_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson1_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson1_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson1_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson2_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson2_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson2_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson2_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson2_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson2_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson2_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson2_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson3_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson3_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson3_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson3_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson3_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson3_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson3_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson3_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson4_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson4_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson4_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson4_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson4_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson4_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson4_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson4_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson5.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson5.asciidoc
@@ -20,6 +20,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -31,6 +32,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson5_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson5_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson5_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson5_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson5_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson5_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson5_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson5_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson6_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson6_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson6_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson6_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson6_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson6_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson6_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson6_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson7.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson7.asciidoc
@@ -20,6 +20,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -31,6 +32,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson7_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson7_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson7_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson7_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson7_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson7_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson7_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson7_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson8_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson8_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson8_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson8_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson8_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson8_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson8_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson8_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson9.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson9.asciidoc
@@ -20,6 +20,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -31,6 +32,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson9_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson9_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson9_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson9_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson9_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson9_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson9_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-lesson9_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-oracle-lesson1.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-oracle-lesson1.asciidoc
@@ -20,6 +20,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -31,6 +32,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-oracle-lesson1_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-oracle-lesson1_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-oracle-lesson1_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-oracle-lesson1_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-oracle-lesson1_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-oracle-lesson1_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-oracle-lesson1_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-oracle-lesson1_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -32,6 +33,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-tutorial-main-page.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-tutorial-main-page.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-tutorial-main-page_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-tutorial-main-page_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-tutorial-main-page_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-tutorial-main-page_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-tutorial-main-page_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-tutorial-main-page_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/wish-list-tutorial-main-page_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/wish-list-tutorial-main-page_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/zend-framework-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/zend-framework-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/zend-framework-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/zend-framework-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/zend-framework-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/zend-framework-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/zend-framework-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/zend-framework-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php/zend-framework-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php/zend-framework-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -54,6 +56,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -111,6 +114,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -133,6 +137,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -152,6 +157,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php_fr.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php_fr.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -39,6 +40,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -54,6 +56,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -111,6 +114,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -133,6 +137,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -152,6 +157,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -36,6 +37,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -54,6 +56,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -120,6 +123,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -154,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -173,6 +178,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -36,6 +37,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -54,6 +56,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -120,6 +123,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -154,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -173,6 +178,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -36,6 +37,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -54,6 +56,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -120,6 +123,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -154,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -173,6 +178,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/php_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/php_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -36,6 +37,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -54,6 +56,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -120,6 +123,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -154,6 +158,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -173,6 +178,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/platform.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/platform.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-tr.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -63,6 +65,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -78,6 +81,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -174,6 +178,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -187,6 +192,7 @@ image::../../images_www/screenshots/platform/five-easy-extend.png[role="left", l
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -214,6 +220,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -229,6 +236,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -244,6 +252,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -262,6 +271,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -284,6 +294,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -323,6 +334,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/platform_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/platform_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-tr.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -59,6 +61,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -123,6 +126,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -150,6 +154,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -169,6 +174,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -191,6 +197,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/platform_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/platform_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-tr.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -62,6 +64,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -77,6 +80,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -170,6 +174,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -183,6 +188,7 @@ image::../../images_www/screenshots/platform/five-easy-extend.png[role="left", l
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -210,6 +216,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -225,6 +232,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -240,6 +248,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -258,6 +267,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -277,6 +287,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -299,6 +310,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -336,6 +348,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/platform_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/platform_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-tr.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -62,6 +64,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -77,6 +80,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -170,6 +174,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -183,6 +188,7 @@ image::../../images_www/screenshots/platform/five-easy-extend.png[role="left", l
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -210,6 +216,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -225,6 +232,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -240,6 +248,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -258,6 +267,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -277,6 +287,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -299,6 +310,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -336,6 +348,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/platform_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/platform_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-tr.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -62,6 +64,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -77,6 +80,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -170,6 +174,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -183,6 +188,7 @@ image::../../images_www/screenshots/platform/five-easy-extend.png[role="left", l
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -210,6 +216,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -225,6 +232,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -240,6 +248,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -258,6 +267,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -277,6 +287,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -299,6 +310,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -336,6 +348,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/platform_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/platform_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-tr.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -62,6 +64,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -77,6 +80,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -170,6 +174,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -183,6 +188,7 @@ image::../../images_www/screenshots/platform/five-easy-extend.png[role="left", l
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -210,6 +216,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -225,6 +232,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -240,6 +248,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -258,6 +267,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -277,6 +287,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -299,6 +310,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -336,6 +348,7 @@ image::https://netbeans.org/images_www/v6/trails/trails-box-br.png[] image::http
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/tools.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/tools.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -36,6 +37,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -78,6 +80,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -100,6 +103,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -119,6 +123,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/tools_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/tools_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -36,6 +37,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -69,6 +71,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -87,6 +90,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -106,6 +110,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/tools_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/tools_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -36,6 +37,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -78,6 +80,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -100,6 +103,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -119,6 +123,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/tools_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/tools_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -36,6 +37,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -78,6 +80,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -100,6 +103,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -119,6 +123,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/tools_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/tools_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -36,6 +37,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -78,6 +80,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -100,6 +103,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -119,6 +123,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/tools_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/tools_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -36,6 +37,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -78,6 +80,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -100,6 +103,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -119,6 +123,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -91,6 +94,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -113,6 +117,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -132,6 +137,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/ajax-quickstart.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/ajax-quickstart.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/ajax-quickstart_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/ajax-quickstart_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/ajax-quickstart_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/ajax-quickstart_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/ajax-quickstart_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/ajax-quickstart_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/ajax-quickstart_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/ajax-quickstart_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/applets.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/applets.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/applets_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/applets_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/applets_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/applets_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/applets_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/applets_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/applets_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/applets_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/framework-adding-support.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/framework-adding-support.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/framework-adding-support_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/framework-adding-support_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/framework-adding-support_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/framework-adding-support_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/framework-adding-support_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/framework-adding-support_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/framework-adding-support_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/framework-adding-support_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/grails-quickstart.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/grails-quickstart.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/grails-quickstart_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/grails-quickstart_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/grails-quickstart_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/grails-quickstart_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/grails-quickstart_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/grails-quickstart_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/grails-quickstart_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/grails-quickstart_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/hibernate-webapp.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/hibernate-webapp.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/hibernate-webapp_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/hibernate-webapp_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/hibernate-webapp_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/hibernate-webapp_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/hibernate-webapp_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/hibernate-webapp_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/hibernate-webapp_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/hibernate-webapp_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-cordova-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-cordova-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-cordova-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-cordova-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-cordova-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-cordova-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-cordova-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-cordova-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-cordova-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-cordova-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-css-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-css-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-css-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-css-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-css-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-css-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-css-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-css-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-css-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-css-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-gettingstarted-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-gettingstarted-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-gettingstarted-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-gettingstarted-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-gettingstarted-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-gettingstarted-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-gettingstarted-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-gettingstarted-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-gettingstarted-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-gettingstarted-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-javascript-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-javascript-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-javascript-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-javascript-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-javascript-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-javascript-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-javascript-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-javascript-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/html5-javascript-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/html5-javascript-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/index.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/index.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Web Technologies Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/web/index_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/index_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Web Technologies Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/web/index_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/index_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Web Technologies Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/web/index_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/index_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Web Technologies Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/web/index_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/index_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Web Technologies Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/web/index_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/index_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Web Technologies Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-dojo.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-dojo.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-dojo_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-dojo_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-dojo_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-dojo_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-dojo_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-dojo_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-dojo_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-dojo_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-jquery_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-jquery_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-jquery_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-jquery_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-jquery_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-jquery_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-jquery_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/js-toolkits-jquery_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf-jpa-weblogic.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf-jpa-weblogic.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf-jpa-weblogic_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf-jpa-weblogic_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf-jpa-weblogic_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf-jpa-weblogic_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf-jpa-weblogic_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf-jpa-weblogic_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf-jpa-weblogic_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf-jpa-weblogic_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-crud.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-crud.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-crud_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-crud_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-crud_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-crud_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-crud_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-crud_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-crud_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-crud_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-intro.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-intro.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-intro_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-intro_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-intro_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-intro_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-intro_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-intro_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-intro_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-intro_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-support.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-support.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-support_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-support_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-support_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-support_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-support_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-support_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-support_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-support_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/jsf20-support_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/jsf20-support_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/mysql-webapp.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/mysql-webapp.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/mysql-webapp_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/mysql-webapp_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/mysql-webapp_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/mysql-webapp_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/mysql-webapp_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/mysql-webapp_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/mysql-webapp_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/mysql-webapp_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/oracle-cloud.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/oracle-cloud.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/oracle-cloud_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/oracle-cloud_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/oracle-cloud_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/oracle-cloud_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/oracle-cloud_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/oracle-cloud_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/oracle-cloud_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/oracle-cloud_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-spring.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-spring.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-spring_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-spring_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-spring_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-spring_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-spring_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-spring_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-spring_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-spring_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-struts.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-struts.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-struts_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-struts_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-struts_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-struts_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-struts_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-struts_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-struts_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-struts_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-wicket.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-wicket.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-wicket_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-wicket_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-wicket_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-wicket_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-wicket_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-wicket_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-wicket_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps-wicket_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/quickstart-webapps_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/security-webapps.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/security-webapps.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/security-webapps_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/security-webapps_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/security-webapps_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/security-webapps_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/security-webapps_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/security-webapps_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web/security-webapps_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web/security-webapps_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web_ca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web_ca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -96,6 +99,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -117,6 +121,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -136,6 +141,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -91,6 +94,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -113,6 +117,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -132,6 +137,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -91,6 +94,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -113,6 +117,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -132,6 +137,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -91,6 +94,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -113,6 +117,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -132,6 +137,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/web_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/web_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -43,6 +44,7 @@ image::../../images_www/v6/trails/trails-box-tr.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -57,6 +59,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -91,6 +94,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -113,6 +117,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left
@@ -131,6 +136,7 @@ image::../../images_www/v6/trails/trails-box-br.png[] image::../../images_www/v6
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/cordova-gettingstarted.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/cordova-gettingstarted.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/cordova-gettingstarted_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/cordova-gettingstarted_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/cordova-gettingstarted_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/cordova-gettingstarted_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/cordova-gettingstarted_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/cordova-gettingstarted_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/cordova-gettingstarted_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/cordova-gettingstarted_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-editing-css.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-editing-css.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-editing-css_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-editing-css_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-editing-css_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-editing-css_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-editing-css_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-editing-css_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-editing-css_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-editing-css_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-gettingstarted_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-gettingstarted_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-gettingstarted_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-gettingstarted_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-gettingstarted_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-gettingstarted_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-gettingstarted_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-gettingstarted_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-js-support.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-js-support.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-js-support_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-js-support_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-js-support_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-js-support_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-js-support_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-js-support_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-js-support_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-js-support_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-knockout-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-knockout-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-knockout-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-knockout-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-knockout-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-knockout-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-knockout-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-knockout-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/html5-knockout-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/html5-knockout-screencast_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/index.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/index.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: HTML5 Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/webclient/index_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/index_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: HTML5 Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/webclient/index_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/index_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: HTML5 Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/webclient/index_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/index_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: HTML5 Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/webclient/index_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/index_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: HTML5 Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-cca.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-cca.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-chatbot.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-chatbot.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-cookbook.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-cookbook.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-crud.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-crud.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-databinding.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-databinding.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-flex.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-flex.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-gettingstarted.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-gettingstarted.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-intermodular.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-intermodular.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-porting.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-porting.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-rest.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-rest.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-settingup.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-settingup.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/webclient/ojet-working.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/webclient/ojet-working.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/client.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/client.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/client_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/client_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/client_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/client_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/client_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/client_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/client_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/client_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower-code-ws.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower-code-ws.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower-code-ws_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower-code-ws_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower-code-ws_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower-code-ws_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower-code-ws_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower-code-ws_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower-code-ws_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower-code-ws_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_overview.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_overview.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_overview_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_overview_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_overview_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_overview_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_overview_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_overview_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_overview_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_overview_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_swing.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_swing.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_swing_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_swing_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_swing_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_swing_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_swing_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_swing_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_swing_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_swing_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_ws.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_ws.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_ws_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_ws_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_ws_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_ws_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_ws_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_ws_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_ws_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_ws_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_wsdl_schema.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_wsdl_schema.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_wsdl_schema_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_wsdl_schema_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_wsdl_schema_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_wsdl_schema_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_wsdl_schema_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_wsdl_schema_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/flower_wsdl_schema_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/flower_wsdl_schema_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/index.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/index.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Web Service Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/websvc/index_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/index_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Web Service Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/websvc/index_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/index_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Web Service Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/websvc/index_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/index_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Web Service Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/websvc/index_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/index_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials
 :jbake-status: published
+:icons: font
 :toc: left
 :toc-title:
 :description: Web Service Tutorials

--- a/netbeans.apache.org/src/content/kb/docs/websvc/intro-ws.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/intro-ws.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/intro-ws_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/intro-ws_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/intro-ws_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/intro-ws_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/intro-ws_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/intro-ws_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/intro-ws_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/intro-ws_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/jax-ws.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/jax-ws.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/jax-ws_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/jax-ws_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/jax-ws_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/jax-ws_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/jax-ws_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/jax-ws_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/jax-ws_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/jax-ws_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/pet-catalog-screencast.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/pet-catalog-screencast.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/pet-catalog-screencast_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/pet-catalog-screencast_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/pet-catalog-screencast_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/pet-catalog-screencast_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/pet-catalog-screencast_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/pet-catalog-screencast_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/pet-catalog-screencast_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/pet-catalog-screencast_zh_CN.asciidoc
@@ -20,6 +20,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/rest.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/rest.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/rest_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/rest_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/rest_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/rest_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/rest_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/rest_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/rest_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/rest_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/wsit.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/wsit.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/wsit_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/wsit_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/wsit_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/wsit_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/wsit_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/wsit_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/wsit_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/wsit_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/zillow.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/zillow.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/zillow_ja.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/zillow_ja.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/zillow_pt_BR.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/zillow_pt_BR.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/zillow_ru.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/zillow_ru.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/kb/docs/websvc/zillow_zh_CN.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/websvc/zillow_zh_CN.asciidoc
@@ -21,6 +21,7 @@
 :jbake-type: tutorial
 :jbake-tags: tutorials 
 :jbake-status: published
+:icons: font
 :syntax: true
 :source-highlighter: pygments
 :toc: left

--- a/netbeans.apache.org/src/content/scss/base/_colors.scss
+++ b/netbeans.apache.org/src/content/scss/base/_colors.scss
@@ -37,3 +37,4 @@ $nb-card-background: #fafafb;
 $nb-green: #a1c535;
 $nb-magenta: #a5073e;
 $nb-blue: #1b6ac6;
+$nb-gray: #888;

--- a/netbeans.apache.org/src/content/scss/common/_netbeans.scss
+++ b/netbeans.apache.org/src/content/scss/common/_netbeans.scss
@@ -305,3 +305,13 @@ table tbody tr:nth-child(2n) {
         }
 }
 
+// CSS for the 'reviewed' paragraph in tutorials
+.reviewed {
+        font-size: 80%;
+        margin-bottom: 2rem;
+        color: $nb-gray;
+        i {
+                color: $nb-green;
+        }
+}
+

--- a/netbeans.apache.org/src/content/templates/tools.gsp
+++ b/netbeans.apache.org/src/content/templates/tools.gsp
@@ -37,6 +37,8 @@
             if (content != null) {
                 String content_file = content.get("file");
                 int i = content_file.lastIndexOf("build/generated-bake");
+                // Adds support for Windows builds
+                i = i == -1 ? content_file.lastIndexOf("build\\generated-bake") : i;
                 file = content_file.substring(i + "build/generated-bake".length());
             }
         %>

--- a/netbeans.apache.org/src/content/templates/tutorial.gsp
+++ b/netbeans.apache.org/src/content/templates/tutorial.gsp
@@ -28,15 +28,35 @@
         <%include "news.gsp"%>
         <div class='grid-container main-content tutorial'>
             <h1 class="sect0">${content.title}</h1>
-            <% if (content.reviewed == null) { %>
+            <% if (content.reviewed == null) { 
+                /* 
+                    jbake's 'content.file' has this structure: "/home/user/directory/of/the/clone/incubator-netbeans-website/netbeans.apache.org/build/generated-bake/content/plugins/index.asciidoc"
+                    we're interested in the part after "generated-bake"
+                */
+                String tutorial_file="/";
+                String tutorial_content_file = content.get("file");
+                int idx = tutorial_content_file.lastIndexOf("build/generated-bake");
+                // Adds support for Windows builds
+                idx = idx == -1 ? tutorial_content_file.lastIndexOf("build\\generated-bake") : idx;
+                tutorial_file = idx == -1 ? "???" + tutorial_content_file : tutorial_content_file.substring(idx + "build/generated-bake".length());
+            %>
             <div class="sectionbody">
               <div class="admonitionblock note">
                 <table>
                   <tbody><tr>
                   <td class="icon"><i class="fa icon-note" title="Note"></i></td>
-                  <td class="content">This tutorial needs a review. You can <a href="/kb/docs/contributing.html">help us review it.</a></td>
+                  <td class="content">This tutorial needs a review. 
+                     You can <a href="https://issues.apache.org/jira/projects/NETBEANS/issues">open a JIRA issue</a>, 
+                     or <a href="https://github.com/apache/incubator-netbeans-website/blob/master/netbeans.apache.org/src${tutorial_file}" title="Edit this tutorial in github">edit it in GitHub </a>
+                     following these <a href="/kb/docs/contributing.html">contribution guidelines.</a></td>
                   </tr></tbody>
                 </table>
+              </div>
+            </div>
+            <% } else { %>
+            <div class="sectionbody">
+              <div class="paragraph">
+                <p class='reviewed'><i class="fa fa-check-circle"></i> Last reviewed in <%= content.reviewed %></p>
               </div>
             </div>
             <% } %>

--- a/netbeans.apache.org/src/content/templates/tutorial.gsp
+++ b/netbeans.apache.org/src/content/templates/tutorial.gsp
@@ -56,7 +56,7 @@
             <% } else { %>
             <div class="sectionbody">
               <div class="paragraph">
-                <p class='reviewed'><i class="fa fa-check-circle"></i> Last reviewed in <%= content.reviewed %></p>
+                <p class='reviewed'><i class="fa fa-check-circle"></i> Last reviewed on <%= content.reviewed %></p>
               </div>
             </div>
             <% } %>


### PR DESCRIPTION
- Added `:icons: font` to all tutorials.
- Green checkmark for tutorials with the `:reviewed: date` metadata entry.
- Added links to JIRA and to "edit in GitHub" in tutorials without the `:reviewed:` metadata tag.