### PR TITLE
Link colors / Header Sizes / Page Titles

### DIFF
--- a/netbeans.apache.org/build.gradle
+++ b/netbeans.apache.org/build.gradle
@@ -216,7 +216,7 @@ task("run", type: JavaExec, group: "Run", overwrite: true) {
     
     main "TomcatMain"
     classpath buildscript.configurations.classpath + files("${rootProject.projectDir}/buildSrc/build/classes/main")
-    args = [bakedDir, 8080, "SHUTDOWN", 8082]
+    args = [bakedDir, 8080, "SHUTDOWN", 8088]
     workingDir = wDir
 }
 

--- a/netbeans.apache.org/src/content/community/committer.asciidoc
+++ b/netbeans.apache.org/src/content/community/committer.asciidoc
@@ -26,8 +26,6 @@
 :toc-title:
 
 
-== How to become a committer (and maybe a PPMC member)
-
 The Committer, Member and (P)PMC Member terms, in particular, have very specific meanings in the Apache Software Foundation
 (see also link:https://www.apache.org/foundation/how-it-works.html[how the ASF works]), and need to be used appropriately to avoid confusion:
 

--- a/netbeans.apache.org/src/content/community/events.asciidoc
+++ b/netbeans.apache.org/src/content/community/events.asciidoc
@@ -16,7 +16,7 @@
      specific language governing permissions and limitations
      under the License.
 ////
-= Events
+= NetBeans Events
 :jbake-type: page
 :jbake-tags: community
 :jbake-status: published

--- a/netbeans.apache.org/src/content/community/index.asciidoc
+++ b/netbeans.apache.org/src/content/community/index.asciidoc
@@ -16,7 +16,7 @@
      specific language governing permissions and limitations
      under the License.
 ////
-= Community
+= Apache NetBeans Community
 :jbake-type: page
 :jbake-tags: community
 :jbake-status: published
@@ -25,18 +25,19 @@
 :toc: left
 :toc-title:
 
-== link:mailing-lists.html[Stay Informed]
-The Apache NetBeans Community link:mailing-lists.html[communicates in many different ways]. See how to stay informed and in touch with other NetBeans users and developers.
+== Stay Informed
 
-== link:/participate/index.html[Participate]
+The Apache NetBeans Community uses the link:mailing-lists.html[mailing lists] as the primary source of comunication. . See how to stay informed and in touch with other NetBeans users and developers.
+
+== Participate
 We welcome link:/participate/index.html[all kind of contributions]. And there are many ways to contribute: see how you can participate in Apache NetBeans.
 
-== link:events.html[NetBeans Events]
+== NetBeans Events
 NetBeans users and developers participate in link:events.html[different events]. See how this works.
 
-== link:who.html[Who We Are]
+== Who We Are
 The Apache NetBeans source code was donated by Oracle to the link:https://www.apache.org[Apache Software Foundation] in 2016.
 Since then many contributors have joined the project. Find out link:who.html[who is who], and link:committer.html[how to become a committer].
 
-== link:nekobean.html[NekoBean]
+== NekoBean
 link:nekobean.html[NekoBean] is a mascot of Apache NetBeans Community.

--- a/netbeans.apache.org/src/content/community/mailing-lists.asciidoc
+++ b/netbeans.apache.org/src/content/community/mailing-lists.asciidoc
@@ -16,7 +16,7 @@
      specific language governing permissions and limitations
      under the License.
 ////
-= Keep informed / Apache NetBeans
+= Mailing Lists
 :jbake-type: page
 :jbake-tags: community
 :jbake-status: published
@@ -26,8 +26,6 @@
 :toc-title: 
 
 [[mailing-lists]]
-== Mailing lists
-
 Mailing lists are the main way to get in touch with the NetBeans Community. Feel free to subscribe and participate. 
 
 Lists are managed with link:https://untroubled.org/ezmlm/[ezmlm], refer to link:https://untroubled.org/ezmlm/manual/[ezmlm manual] for useful help commands.

--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -31,20 +31,21 @@ for important requirements for download pages for Apache projects.
 :description: Apache NetBeans Releases Page
 :toc: left
 :toc-title:
+:linkattrs:
 
 [[releases]]
 == Apache NetBeans 10.0
 
-Apache NetBeans 10.0 is the latest version of the IDE.
+Apache NetBeans 10.0 is the latest version of the IDE. It was released on the 27th of December, 2018.
 
-- Apache NetBeans 10.0 link:nb100/index.html[features]
-- link:nb100/nb100.html[Download] Apache NetBeans 10.0, released on the 27th of December, 2018.
+link:nb100/index.html[Features, role="button"] link:nb100/nb100.html[Download, role="button success"]
 
 [[previous]]
 == Apache NetBeans 9.0
 
-- Apache NetBeans 9.0 link:nb90/[features]
-- link:nb90/nb90.html[Download] Apache NetBeans 9.0, released on the 29th of July, 2018.
+Apache NetBeans 9.0 was released on the 29th of July, 2018.
+
+link:nb90/[Features, role="button"] link:nb90/nb90.html[Download, role="button success"] 
 
 == Pre-Apache NetBeans versions
 

--- a/netbeans.apache.org/src/content/download/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/index.asciidoc
@@ -23,7 +23,7 @@ See https://www.apache.org/dev/release-download-pages.html
 for important requirements for download pages for Apache projects.
 
 ////
-= Releases / Apache NetBeans
+= Apache NetBeans Releases
 :jbake-type: page
 :jbake-tags: download
 :jbake-status: published
@@ -33,18 +33,18 @@ for important requirements for download pages for Apache projects.
 :toc-title:
 
 [[releases]]
-== Apache NetBeans 10.0 (link:nb100/nb100.html[download])
+== Apache NetBeans 10.0
 
 Apache NetBeans 10.0 is the latest version of the IDE.
 
-- link:nb100/index.html[Apache NetBeans 10.0 Features]
-- link:nb100/nb100.html[Apache NetBeans 10.0], released on the 27th of December, 2018.
+- Apache NetBeans 10.0 link:nb100/index.html[features]
+- link:nb100/nb100.html[Download] Apache NetBeans 10.0, released on the 27th of December, 2018.
 
 [[previous]]
 == Apache NetBeans 9.0
 
-- link:nb90/[Apache NetBeans 9.0 Features]
-- link:nb90/nb90.html[Apache NetBeans 9.0], released on the 29th of July, 2018.
+- Apache NetBeans 9.0 link:nb90/[features]
+- link:nb90/nb90.html[Download] Apache NetBeans 9.0, released on the 29th of July, 2018.
 
 == Pre-Apache NetBeans versions
 

--- a/netbeans.apache.org/src/content/download/nb100/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb100/index.asciidoc
@@ -16,7 +16,7 @@
      specific language governing permissions and limitations
      under the License.
 ////
-= Apache NetBeans IDE 10.0 features
+= Apache NetBeans (incubating) 10.0 Features
 :jbake-type: page
 :jbake-tags: 10.0 features
 :jbake-status: published
@@ -39,15 +39,10 @@ nb100/nb101.asciidoc (if any) -> NetBeans 10.1 release information
 ////
 
 
-== Apache NetBeans IDE (incubating) 10.0 
-
-Apache NetBeans (incubating) 10.0 is the second major release of the Apache NetBeans IDE.
+Apache NetBeans (incubating) 10.0 is the second major release of the Apache NetBeans IDE. It was released in December, 2018. link:/download/nb100/nb100.html[Click here to download] this release.
 
 This release is focused in adding support for JDK 11, JUnit 5, PHP, JavaScript and Groovy, as well in solving many issues.
 
-=== Downloads
-
-- For download instructions please see link:/download/nb100/nb100.html[Apache NetBeans 10.0], released in December 2018.
 
 ////
 To display a feature do as follows:
@@ -84,7 +79,7 @@ Note: When rendered into HTML, the images will automatically be wrapped around '
 
 ////
 
-=== JDK 11 Support
+== JDK 11 Support
 
 JDK 11 support has been enhanced in the following ways:
 
@@ -102,14 +97,14 @@ image:var-autocomplete-1st-param.png[Code completion support for var type lambda
 
 See the link:https://cwiki.apache.org/confluence/display/NETBEANS/Feature%3A+JDK+11[JDK 11 Confluence Page] for more detailed features.
 
-=== PHP Support
+== PHP Support
 
 All the PHP support for NetBeans 10 was contributed by our NetBeans committer
 link:http://netbeans.apache.org/community/who.html#_junichi_yamamoto[Junichi Yamamoto]. 
 
 These are some of the new features:
 
-==== PHP 7.3
+=== PHP 7.3
 [.feature]
 --
 
@@ -127,7 +122,7 @@ image::nb100-php73-flexible-heredoc-and-nowdoc-syntaxes.png[role="left"]
 
 --
 
-==== PHP 7.2
+=== PHP 7.2
 [.feature]
 --
 For PHP 7.2 we support trailing commas in list syntax, coloring for object types and PHP version in project properties.
@@ -135,7 +130,7 @@ For PHP 7.2 we support trailing commas in list syntax, coloring for object types
 image::nb100_php_editor_php_version_72_trailing_commas_in_list_syntax.png[role="right"]
 --
 
-==== PHP 7.1
+=== PHP 7.1
 [.feature]
 --
 For PHP 7.1 we have class constant visibility, multi-catch exception handling, nullable types, support for keys in list(), 
@@ -144,14 +139,14 @@ coloring for new keywords (void, iterable).
 image::nb100_php_editor_class_constant_visibility_01.png[role="left"]
 --
 
-==== More PHP features
+=== More PHP features
 
 And more: context sensitive lexer, PHPStan support, debugger, twig, hints, suggestions, code completion... visit link:https://cwiki.apache.org/confluence/display/NETBEANS/Feature%3A+PHP[PHP Features Page] 
 and link:https://cwiki.apache.org/confluence/display/NETBEANS/Apache+NetBeans+10.0+New+and+Noteworthy#ApacheNetBeans10.0NewandNoteworthy-OpenJDK[NetBeans 10 New and Noteworthy] 
 for more details on PHP support.
 
 
-=== JUnit 5
+== JUnit 5
 
 [.feature]
 --

--- a/netbeans.apache.org/src/content/download/nb100/nb100.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb100/nb100.asciidoc
@@ -23,24 +23,17 @@ See https://www.apache.org/dev/release-download-pages.html
 for important requirements for download pages for Apache projects.
 
 ////
-= Apache NetBeans 10.0 / Apache NetBeans
+= Downloading Apache NetBeans (incubating) 10.0 
 :jbake-type: page
 :jbake-tags: download
 :jbake-status: published
-:keywords: Apache NetBeans 10.0 release
-:description: Apache NetBeans 10.0 release information
+:keywords: Apache NetBeans 10.0 Download
+:description: Apache NetBeans 10.0 Download
 :toc: left
 :toc-title:
 
-== Apache NetBeans 10.0 Release
-
-Apache NetBeans (incubating) 10.0 announced on the 27th of December, 2018.
-
-=== Main features
-
+Apache NetBeans (incubating) 10.0 was announced on the 27th of December, 2018.
 See link:/download/nb100/index.html[Apache NetBeans 10.0 Features] for a full list of features.
-
-=== Downloading
 
 ////
 NOTE: It's mandatory to link to the source. It's optional to link to the binaries.
@@ -69,7 +62,7 @@ Also see the following YouTube clip:
 
 video::O8cwpEY1OAQ[youtube, title="The Rough Guide to Apache NetBeans 10"]
 
-=== Building from source
+== Building from source
 
 To build Apache NetBeans (incubating) 10.0 from source you need:
 
@@ -81,7 +74,7 @@ Once you have everything installed then:
 1. Unzip link:https://www.apache.org/dyn/closer.cgi/incubator/netbeans/incubating-netbeans/incubating-10.0/incubating-netbeans-10.0-source.zip[incubating-netbeans-10.0-source.zip] in a directory of your liking.
 2. `cd` to that directory, and then run `ant` to build the Apache NetBeans IDE. Once built you can run the IDE by typing `./nbbuild/netbeans/bin/netbeans`
 
-=== Community approval
+== Community approval
 
 As in any other Apache Project, the Apache NetBeans Community approved this release through the following voting processes in our link:/community/mailing-lists.html[mailing lists] :
 
@@ -90,7 +83,7 @@ As in any other Apache Project, the Apache NetBeans Community approved this rele
 - link:https://lists.apache.org/thread.html/12e90e3171b85cb1b2249c59fe25caeefd9f6edf0dc14b9916b0af6f@%3Cgeneral.incubator.apache.org%3E[IPMC vote]
 - link:https://lists.apache.org/thread.html/baaaee55cb4e4daf8c6d9527cfbcf15d05ef58b50f9ee6d02146afa0@%3Cgeneral.incubator.apache.org%3E[IPMC vote result]
 
-=== Release information
+== Release information
 
 Please visit the link:https://cwiki.apache.org/confluence/display/NETBEANS/Apache+NetBeans+10[Apache NetBeans 10 page] for further details.
 

--- a/netbeans.apache.org/src/content/download/nb90/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb90/index.asciidoc
@@ -16,7 +16,7 @@
      specific language governing permissions and limitations
      under the License.
 ////
-= Apache NetBeans IDE 9.0 features
+= Apache NetBeans (incubating) 9.0 Features
 :jbake-type: page
 :jbake-tags: 9.0 features
 :jbake-status: published
@@ -27,20 +27,13 @@
 :toc-title: 
 :toclevels: 4
 
-== Apache NetBeans IDE (incubating) 9.0 
+Apache NetBeans 9.0 is the first release of the Apache NetBeans IDE, it was released
+on July 2018. link:/download/nb90/nb90.html[Click here to download] this release.
 
-Apache NetBeans 9.0 is the first release of the Apache NetBeans IDE.
+The main goals for this release are IP clearance of the Oracle code donation and Java 9 and Java 10 Support.
 
-The main goals for this release are
+Features include:
 
-- IP clearance of the Oracle code donation.
-- Java 9 and 10 Support.
-
-=== Downloads
-
-- See link:/download/nb90/nb90.html[Apache NetBeans 9.0], released in July 2018.
-
-=== New Features
 
 ////
 To display a feature do as follows:
@@ -77,7 +70,7 @@ Note: When rendered into HTML, the images will automatically be wrapped around '
 
 ////
 
-==== Supporting Local Variable Type Inference
+== Supporting Local Variable Type Inference
 
 New hints, error handlers, and refactorings for transforming to/from the new JDK 10 "var" type:
 
@@ -101,7 +94,7 @@ Var type is not supported for array initializer. This hint helps correct compila
 
 image:invalidArray.png[New Error Hint for var Array declaration, title="New Error Hint for var Array declaration", role="left", link="invalidArray.png"]
 
-==== Supporting the Jigsaw Module System
+== Supporting the Jigsaw Module System
 [.feature]
 --
 image:nb90-module-info.png[Adding module-info.java, title="Adding module-info.java", role="left", link="nb90-module-info.png"]
@@ -120,7 +113,7 @@ image:nb90-module-info-completion.png[Autocompletion in module-info.java, title=
 Of course, we provide full autocompletion for `module-info.java`
 --
 
-==== A brand new Java Modular Application project type
+== A brand new Java Modular Application project type
 [.feature]
 --
 image:nb90-new-multi-module.png[Java Modular Application, title="New Java Modular Application Project Type", role="left", link="nb90-new-multi-module.png"]
@@ -134,7 +127,7 @@ appropriate `exports` and `requires` in `module-info.java`, and all modules
 in the project will be compiled at once.
 --
 
-==== Java Shell support
+== Java Shell support
 [.feature]
 --
 image:nb90-javashell.png[Java Shell Support, title="Java Shell Support", role="left", link="nb90-javashell.png"]

--- a/netbeans.apache.org/src/content/download/nb90/nb90.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb90/nb90.asciidoc
@@ -23,7 +23,7 @@ See https://www.apache.org/dev/release-download-pages.html
 for important requirements for download pages for Apache projects.
 
 ////
-= Apache NetBeans 9.0 / Apache NetBeans
+= Downloading Apache NetBeans (incubating) 9.0 
 :jbake-type: page
 :jbake-tags: download
 :jbake-status: published
@@ -32,15 +32,8 @@ for important requirements for download pages for Apache projects.
 :toc: left
 :toc-title:
 
-== Apache NetBeans 9.0 Release
-
-Apache NetBeans (incubating) 9.0 announced on the 29th of July, 2018.
-
-=== Main features
-
+Apache NetBeans (incubating) 9.0 was announced on the 29th of July, 2018.
 See link:/download/nb90/index.html[Apache NetBeans 9.0 Features] for a full list of features.
-
-=== Downloading
 
 ////
 NOTE: It's mandatory to link to the source. It's optional to link to the binaries.
@@ -69,7 +62,7 @@ NOTE: Using https below is highly recommended.
 ////
 Officially, it is important that you link:https://www.apache.org/dyn/closer.cgi#verify[verify the integrity] of the downloaded files using the PGP signatures (.asc file) or a hash (.sha1 files).  The PGP keys used to sign this release are available link:https://dist.apache.org/repos/dist/release/incubator/netbeans/KEYS[here].
 
-=== Building from source
+== Building from source
 
 To build Apache NetBeans (incubating) from source you need:
 
@@ -82,7 +75,7 @@ Once you have everything installed then:
 2. `cd` to that directory, and then run `ant` to build the Apache NetBeans IDE. Once built you can run the IDE by typing `./nbbuild/netbeans/bin/netbeans` (or `.\nbbuild\netbeans\bin\netbeans` in
 Windows).
 
-=== Community approval
+== Community approval
 
 As in any other Apache Project, the Apache NetBeans Community approved this release through the following voting processes in our link:/community/mailing-lists.html[mailing lists] :
 
@@ -91,6 +84,6 @@ As in any other Apache Project, the Apache NetBeans Community approved this rele
 - link:https://lists.apache.org/thread.html/ab58e2c75d260a91851d8def412b1ef6648aaf4f690b205aaaf53924@%3Cgeneral.incubator.apache.org%3E[IPMC vote]
 - link:https://lists.apache.org/thread.html/0cdb410ae900833f32c9d9546c8bf2580e54e8777a869240241b84b2@%3Cgeneral.incubator.apache.org%3E[IPMC vote result]
 
-=== Known issues
+== Known issues
 
 Please visit link:https://cwiki.apache.org/confluence/display/NETBEANS/Apache+NetBeans+9.0[this confluence page] for a list of known issues.

--- a/netbeans.apache.org/src/content/help/index.asciidoc
+++ b/netbeans.apache.org/src/content/help/index.asciidoc
@@ -16,7 +16,7 @@
      specific language governing permissions and limitations
      under the License.
 ////
-= Getting Help / Apache NetBeans
+= Getting Help
 :jbake-type: page
 :jbake-tags: community
 :jbake-status: published
@@ -51,10 +51,9 @@ These other resources are available:
 - The link:https://github.com/apache/incubator-netbeans-website[current Apache NetBeans website] (i.e., this website) is also hosted at github.
 
 [[wiki]]
-== link:/wiki/index.asciidoc[Apache NetBeans Wiki]
+== Apache NetBeans Wiki
 
 Some parts of the NetBeans Wiki link:/wiki/index.asciidoc[have been ported], but need review.
-
 
 [[support]]
 == Support

--- a/netbeans.apache.org/src/content/participate/index.asciidoc
+++ b/netbeans.apache.org/src/content/participate/index.asciidoc
@@ -16,7 +16,7 @@
      specific language governing permissions and limitations
      under the License.
 ////
-= Participate / Apache NetBeans
+= Participating in Apache NetBeans
 :jbake-type: page
 :jbake-tags: community
 :jbake-status: published
@@ -33,23 +33,27 @@ being part of our Community.
 You can participate in the Apache NetBeans (Incubating) Project in many different ways.
 Here are some ideas:
 
-== link:submit-pr.html[Contributing code]
+== Contributing code
+
 See link:submit-pr.html[contributing code] to learn how to contribute code to the Apache NetBeans project.
 
-== link:report-issue.html[Reporting issues]
+== Reporting issues
+
 See link:report-issue.html[reporting issues] for instructions on how to report an issue.
 
-== link:netcat.html[Join the NetCAT program]
+== Join the NetCAT program
 The NetBeans Community Acceptance Testing program (link:netcat.html[NetCAT]) has helped stabilize development
 builds for years.
 
 [[documentation]]
 == Improving the documentation
+
 We will be porting existing NetBeans documentation soon. Consider joining the
 link:/community/mailing-lists.html[dev mailing list] for updates on how to help with this task.
 
 [[asf]]
 == Contributing to the ASF
+
 You may also want to consider link:https://www.apache.org/foundation/contributing.html[donating to the
 Apache Software Foundation], joining the link:https://www.apache.org/foundation/sponsorship.html[ASF
 Sponsorship Program], or link:https://www.apache.org/foundation/buy_stuff.html[buying ASF merchandise].

--- a/netbeans.apache.org/src/content/participate/netcat.asciidoc
+++ b/netbeans.apache.org/src/content/participate/netcat.asciidoc
@@ -16,7 +16,7 @@
      specific language governing permissions and limitations
      under the License.
 ////
-= NetCAT / Apache NetBeans
+= NetCAT 
 :jbake-type: page
 :jbake-tags: community
 :jbake-status: published

--- a/netbeans.apache.org/src/content/participate/report-issue.asciidoc
+++ b/netbeans.apache.org/src/content/participate/report-issue.asciidoc
@@ -16,7 +16,7 @@
      specific language governing permissions and limitations
      under the License.
 ////
-= Reporting issues / Apache NetBeans
+= Reporting issues
 :jbake-type: page
 :jbake-tags: community
 :jbake-status: published

--- a/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
+++ b/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
@@ -16,7 +16,7 @@
      specific language governing permissions and limitations
      under the License.
 ////
-= Submitting Pull Requests / Apache NetBeans
+= Submitting Pull Requests
 :jbake-type: page
 :jbake-tags: community
 :jbake-status: published
@@ -27,8 +27,6 @@
 :toc-title: 
 
 [contributing-code]
-== Contributing Code
-
 Contributing code to the Apache NetBeans project is not very different to contributing code for any other Apache software project,
 so the link:https://www.apache.org/dev/contributors[Apache's Guide for New Project Contributors] is worth a read.
 

--- a/netbeans.apache.org/src/content/plugins/index.asciidoc
+++ b/netbeans.apache.org/src/content/plugins/index.asciidoc
@@ -16,7 +16,7 @@
      specific language governing permissions and limitations
      under the License.
 ////
-= Plugins / Apache NetBeans
+= Apache NetBeans Plugins
 :jbake-type: page
 :jbake-tags: community
 :jbake-status: published
@@ -25,7 +25,6 @@
 :toc: left
 :toc-title:
 
-== Apache NetBeans Plugins
 
 The NetBeans IDE and the NetBeans Platform are built on top of a modular architecture, and can be enhanced with plugins. 
 

--- a/netbeans.apache.org/src/content/scss/base/_colors.scss
+++ b/netbeans.apache.org/src/content/scss/base/_colors.scss
@@ -27,7 +27,6 @@ $nb-color-light-blue: #538ec7;
 
 $nb-color-bg-blue: #eff0f1;
 
-$nb-link-color: $nb-color-dark-blue;
 $nb-topbar-background: #fafafb;
 $nb-body-background: #fff;
 $nb-pre-background: #fafafb;
@@ -38,3 +37,7 @@ $nb-green: #a1c535;
 $nb-magenta: #a5073e;
 $nb-blue: #1b6ac6;
 $nb-gray: #888;
+
+$nb-link-color: $nb-magenta;
+$nb-header-color: $nb-blue;
+

--- a/netbeans.apache.org/src/content/scss/base/_fonts.scss
+++ b/netbeans.apache.org/src/content/scss/base/_fonts.scss
@@ -17,11 +17,11 @@
  * under the License.
  */
 
-$font-family: 'Lato', sans-serif;
-$font-size: 12pt;
+$font-family: 'Open Sans', 'IBM Plex Sans', sans-serif;
+$font-size: 16px;
 $font-size-small: 10pt;
 
-$font-family-code: Consolas,Menlo,Monaco,'IBM Plex Mono', Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New,monospace,sans-serif;
+$font-family-code: Consolas,Menlo,Monaco,'IBM Plex Mono', 'Lucida Console','Liberation Mono','DejaVu Sans Mono','Bitstream Vera Sans Mono','Courier New',monospace,sans-serif;
 
 pre, code {
     font-family: $font-family-code;

--- a/netbeans.apache.org/src/content/scss/base/_settings.scss
+++ b/netbeans.apache.org/src/content/scss/base/_settings.scss
@@ -147,14 +147,17 @@ $header-styles: (
     'h4': ('font-size': 18),
     'h5': ('font-size': 17),
     'h6': ('font-size': 16),
+    'pre': ('font-size': 16),
   ),
+  /* https://type-scale.com, minor-third, rounded */
   medium: (
-    'h1': ('font-size': 48),
-    'h2': ('font-size': 40),
-    'h3': ('font-size': 31),
-    'h4': ('font-size': 25),
-    'h5': ('font-size': 20),
+    'h1': ('font-size': 40),
+    'h2': ('font-size': 33),
+    'h3': ('font-size': 27),
+    'h4': ('font-size': 23),
+    'h5': ('font-size': 19),
     'h6': ('font-size': 16),
+    'pre': ('font-size': 16),
   ),
 );
 $header-text-rendering: optimizeLegibility;

--- a/netbeans.apache.org/src/content/scss/base/_settings.scss
+++ b/netbeans.apache.org/src/content/scss/base/_settings.scss
@@ -67,7 +67,7 @@
 // 1. Global
 // ---------
 
-$global-font-size: 100%;
+$global-font-size: 16px;
 /*$global-width: rem-calc(1200);*/
 $global-width: 62.5rem;
 $global-lineheight: 1.5;
@@ -135,7 +135,7 @@ $block-grid-max: 8;
 $header-font-family: $body-font-family;
 $header-font-weight: $global-weight-normal;
 $header-font-style: normal;
-$font-family-monospace: Consolas, 'Liberation Mono', Courier, monospace;
+$font-family-monospace: Consolas, Menlo, 'Liberation Mono', Courier, monospace;
 $header-color: inherit;
 $header-lineheight: 1.4;
 $header-margin-bottom: 0.5rem;
@@ -147,7 +147,8 @@ $header-styles: (
     'h4': ('font-size': 18),
     'h5': ('font-size': 17),
     'h6': ('font-size': 16),
-    'pre': ('font-size': 16),
+    'pre': ('font-size': 12),
+    'code': ('font-size': 12),
   ),
   /* https://type-scale.com, minor-third, rounded */
   medium: (
@@ -158,6 +159,7 @@ $header-styles: (
     'h5': ('font-size': 19),
     'h6': ('font-size': 16),
     'pre': ('font-size': 16),
+    'code': ('font-size': 12),
   ),
 );
 $header-text-rendering: optimizeLegibility;

--- a/netbeans.apache.org/src/content/scss/common/_netbeans.scss
+++ b/netbeans.apache.org/src/content/scss/common/_netbeans.scss
@@ -24,12 +24,10 @@
 
 html {
   font-family: $font-family;
-  font-size: $font-size;
 }
 
 body {
   font-family: $font-family;
-  font-size: $font-size;
   background-color: $nb-body-background;
 }
 
@@ -67,7 +65,7 @@ a, a:hover {
 
 .h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6 {
   font-family: $font-family;
-  color: $nb-color-mid-blue;
+  color: $nb-blue;
 }
 
 code {
@@ -202,7 +200,7 @@ section.hero {
       font-size: $font-size-small;
       color: $nb-color-mid-blue;
       a {
-        color: $nb-color-darkest-blue;
+        color: $nb-link-color;
       }
     }
   }

--- a/netbeans.apache.org/src/content/templates/head.gsp
+++ b/netbeans.apache.org/src/content/templates/head.gsp
@@ -37,7 +37,7 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
     <meta name="msapplication-TileColor" content="#ffc40d">
     <meta name="theme-color" content="#ffffff">
-    <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet"> 
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet"> 
     <!--
         Licensed to the Apache Software Foundation (ASF) under one
         or more contributor license agreements.  See the NOTICE file

--- a/netbeans.apache.org/src/content/templates/page.gsp
+++ b/netbeans.apache.org/src/content/templates/page.gsp
@@ -27,6 +27,7 @@
         <%include "menu.gsp"%>
         <%include "news.gsp"%>
         <div class='grid-container main-content'>
+            <h1 class="sect0">${content.title}</h1>
             ${content.body}
             <%include "tools.gsp"%>
         </div>

--- a/netbeans.apache.org/src/content/templates/wiki.gsp
+++ b/netbeans.apache.org/src/content/templates/wiki.gsp
@@ -38,10 +38,9 @@
 
         <script src="/js/vendor/jquery-3.2.1.min.js"></script>
         <script src="/js/vendor/what-input.js"></script>
+        <script src="/js/vendor/jquery.colorbox-min.js"></script>
         <script src="/js/vendor/foundation.min.js"></script>
         <script src="/js/netbeans.js"></script>
-        <script src="/js/vendor/jquery.colorbox-min.js"></script>
-        <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
         <script>
             <% // NOTE: Plain jquery stuff needs to be quoted in gsp pages %>
             ${'$(function(){ $(document).foundation(); });'}


### PR DESCRIPTION
- Links are magenta now (using same colors as in the logo), to differentiate them from headers.
- Using "Level 0" title as the title in the page (same as in tutorials).
- Redesigned some pages.
- More clear distinction between the download page and the features page.
- Changed fonts to "Open Sans".

NOTE: Please Squash & Merge.