### PR TITLE
Fix responsive menu flashing

### DIFF
--- a/netbeans.apache.org/src/content/scss/common/_netbeans.scss
+++ b/netbeans.apache.org/src/content/scss/common/_netbeans.scss
@@ -35,6 +35,21 @@ body {
   background-color: $nb-topbar-background;
 }
 
+/* https://foundation.zurb.com/sites/docs/responsive-navigation.html#preventing-fouc */
+.no-js {
+  @include breakpoint(small only) {
+    .top-bar {
+      display: none;
+    }
+  }
+
+  @include breakpoint(medium) {
+    .title-bar {
+      display: none;
+    }
+  }
+}
+
 .top-bar {
   background-color: $nb-topbar-background;
   box-shadow: 0 1px 0 rgba(12,13,14,0.1),0 1px 3px rgba(12,13,14,0.1),0 4px 20px rgba(12,13,14,0.035),0 1px 1px rgba(12,13,14,0.025);
@@ -57,7 +72,6 @@ body {
     }
   }
 }
-
 
 a, a:hover {
   color: $nb-link-color;


### PR DESCRIPTION
Removes the black mobile title bar that shows up for a split second when loading the page on medium display sizes. Look at [this video at the given timestamp](https://youtu.be/0ovc902VWMQ?t=153) to see the error. The same problem occurs on small display sizes with the top bar (also fixed with this PR).