### PR TITLE
Reduce carousel pop in on landing page

### DIFF
--- a/netbeans.apache.org/src/content/scss/common/_netbeans.scss
+++ b/netbeans.apache.org/src/content/scss/common/_netbeans.scss
@@ -48,6 +48,16 @@ body {
       display: none;
     }
   }
+
+  .orbit-container {
+    height: auto;
+  }
+  .orbit-slide {
+    display: none;
+  }
+  .orbit-slide.is-active {
+    display: block;
+  }
 }
 
 .top-bar {
@@ -160,7 +170,6 @@ section.hero {
   color: #fff;
   position: relative;
   padding: 12px 0 0 0;
-  margin-bottom: 1.5em;
   .grid-container {
     .cell {
       h1, p {
@@ -177,6 +186,10 @@ section.hero {
   background: linear-gradient(rgba(27, 106, 198, 0.88), rgba(46, 144, 232, 0.84)), url("/images/hero-background.jpg") no-repeat;
   background-size: cover;
   background-position: center bottom;
+}
+
+.hero.news {
+  margin-bottom: 1.5em;
 }
 
 /*.netbeans-bg {


### PR DESCRIPTION
Reduce the amount the carousel / slider pushes down the landing page content when JavaScript is first executed.