### PR TITLE
Remove overlapping carousel controls on mobile devices

### DIFF
--- a/netbeans.apache.org/src/content/templates/slider.gsp
+++ b/netbeans.apache.org/src/content/templates/slider.gsp
@@ -21,7 +21,7 @@
 
 <div class="orbit" role="region" aria-label="Apache NetBeans News" data-orbit>
   <div class="orbit-wrapper nb-orbit">
-    <div class="orbit-controls">
+    <div class="orbit-controls show-for-medium">
       <button class="orbit-previous"><span class="show-for-sr">Previous Slide</span>&#9664;&#xFE0E;</button>
       <button class="orbit-next"><span class="show-for-sr">Next Slide</span>&#9654;&#xFE0E;</button>
     </div>


### PR DESCRIPTION
The carousel controls overlap the slide content on mobile devices. Swiping left / right works, so they are redundant anyway.