### PR TITLE
Fixed table widths, added keyboard graphics

### DIFF
--- a/netbeans.apache.org/src/content/kb/docs/java/editor-codereference.asciidoc
+++ b/netbeans.apache.org/src/content/kb/docs/java/editor-codereference.asciidoc
@@ -31,6 +31,8 @@
 :icons: font
 :description: Code Assistance in the NetBeans IDE Java Editor: A Reference Guide - Apache NetBeans
 :keywords: Apache NetBeans, Tutorials,  Code Assistance in the NetBeans IDE Java Editor: A Reference Guide
+:experimental:
+:backslash: &#92;
 
 //================================================= The Title and Metadata (End)
 
@@ -50,17 +52,17 @@ The purpose of any integrated development environment (IDE) is to maximize produ
 
 Code formatting allows you to set up the editor to layout your source code in the way that you find most preferable and comfortable to work with. When you want to format your code simply press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Alt-Shift-F`
-|*macOS*(TM) |`Ctrl-Shift-F`
+|*Windows*(TM)/*Linux* |kbd:[Alt+Shift+F]
+|*macOS*(TM) |kbd:[Ctrl+Shift+F]
 |===
 
 or, select *Source > Format* from the menu bar or, right-click and select *Format*. Your code will then be formatted according to the rules specified in the Formatting pane.
 
 To customize the formatting behaviour, open the formatting pane by selecting:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Editor > Formatting
 |*macOS*(TM) |NetBeans > Preferences... > Editor > Formatting
@@ -76,7 +78,7 @@ By default, the editor automatically inserts matching pairs for braces, brackets
 
 If, for some reason, this feature is disabled, you can enable it by selecting:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Editor > Code Completion
 |*macOS*(TM) |NetBeans > Preferences... > Editor > Code Completion
@@ -90,7 +92,7 @@ NOTE: Do not take any notice of the indicated error, because it does not propose
 
 To customize the highlight colors, select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Fonts & Colors > Highlighting
 |*macOS*(TM) |NetBeans > Preferences... > Fonts & Colors > Highlighting
@@ -110,7 +112,7 @@ More options for collapsing and expanding code blocks can be found by selecting 
 
 To customize the code folding options select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Editor > Folding
 |*macOS*(TM) |NetBeans > Preferences... > Editor > Folding
@@ -124,7 +126,7 @@ then select *Language: Java*. There you will find various options.
 
 To customize keyboard shortcuts, select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Keymap
 |*macOS*(TM) |NetBeans > Preferences... > Keymap
@@ -152,11 +154,11 @@ The editor helps you quickly complete or generate code through the "smart" code 
 
 === Invoking Code Completion
 
-To invoke code completion press  `Ctrl-Space` or, choose *Source > Complete Code...* from the menu bar and a list of appropriate suggestions is presented to you. As you continue to type, code completion becomes more focussed and the list shortens. The list includes options imported in your source file and symbols from the  `java.lang`  package.
+To invoke code completion press  kbd:[Ctrl+Space] or, choose *Source > Complete Code...* from the menu bar and a list of appropriate suggestions is presented to you. As you continue to type, code completion becomes more focussed and the list shortens. The list includes options imported in your source file and symbols from the  `java.lang`  package.
 
 To customize the code completion settings, select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows* (TM) |Tools > Options > Editor > Code Completion
 |*macOS* (TM) |NetBeans > Preferences... > Editor > Code Completion
@@ -166,23 +168,23 @@ You can set code completion to pop-up an options list either automatically or, o
 
 To add characters that will invoke code completion, select the *Language: Java* pane and type your characters in the *Auto Popup Triggers for Java:* field. The code completion list will pop-up every time you type one of your specified characters, simply select your desired option, hit return or "double-click", for it to be entered into your document.
 
-When the *Auto Popup Completion Window* checkbox is not selected, you need to press  `Ctrl-Space`  each time you want to invoke code completion.
+When the *Auto Popup Completion Window* checkbox is not selected, you need to press kbd:[Ctrl+Space] each time you want to invoke code completion.
 
-Instead of using  `Ctrl-Space`  for code completion, you can use "hippie completion". Hippie completion analyzes text in the visible scope by searching your current document and, if not found, in other documents. Hippie completion then provides suggestions to complete the current word with a keyword, class name, method, or variable. To invoke hippie completion press:
+Instead of using kbd:[Ctrl+Space]  for code completion, you can use "hippie completion". Hippie completion analyzes text in the visible scope by searching your current document and, if not found, in other documents. Hippie completion then provides suggestions to complete the current word with a keyword, class name, method, or variable. To invoke hippie completion press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Ctrl-K`
-|*macOS*(TM) |`Command-K`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+K]
+|*macOS*(TM) |kbd:[Command+K]
 |===
 
 and the editor automatically completes the word you're typing. Repeatedly pressing the appropriate key combination will cycle once through all available options. If you go past your desired option then press the shift key as well as your key combination and you can reverse.
 
-The first time  `Ctrl-Space`  is pressed only items matching the type, in this example an  `int`, are shown.
+The first time kbd:[Ctrl+Space] is pressed only items matching the type, in this example an  `int`, are shown.
 
 image::images/codecompletion3.png[]
 
-Press  `Ctrl-Space`  a second time and _all_ available items are shown, regardless of whether they match the provided type, as shown below.
+Press kbd:[Ctrl+Space] a second time and _all_ available items are shown, regardless of whether they match the provided type, as shown below.
 
 image::images/codecompletion4.png[]
 
@@ -198,7 +200,7 @@ In the example below, the editor suggests inserting the  `LinkedHashMap`  constr
 
 image::images/smartcompletion1.png[]
 
-If the "smart" suggestions are not the ones you want to use, press  `Ctrl-Space`  again to see the complete list.
+If the "smart" suggestions are not the ones you want to use, press kbd:[Ctrl+Space] again to see the complete list.
 
 //==============================================================================
 
@@ -206,7 +208,7 @@ If the "smart" suggestions are not the ones you want to use, press  `Ctrl-Space`
 
 Instead of typing consecutive characters, and then calling code completion, you can type the initial capital letters of the word you're interested in.
 
-For example, type  `IE` , press  `Ctrl-Space` , and you will see a list of suggestions that match via camel case completion using the letter  `I`  and then the letter  `E` .
+For example, type  `IE` , press  kbd:[Ctrl+Space] , and you will see a list of suggestions that match via camel case completion using the letter  `I`  and then the letter  `E` .
 
 image::images/camelcase.png[]
 
@@ -226,7 +228,7 @@ image::images/keywords.png[]
 
 When you are adding a new field or a variable, use code completion to choose a name that matches its type.
 
-Type a prefix for the new name, press  `Ctrl-Space`  and select the name you want to use from the list of suggestions.
+Type a prefix for the new name, press  kbd:[Ctrl+Space]  and select the name you want to use from the list of suggestions.
 
 image::images/names.png[]
 
@@ -236,14 +238,14 @@ image::images/names.png[]
 
 The editor determines the most likely parameters for variables, methods, or fields and displays the suggestions in a pop-up box.
 
-For example, when you select a method from the code completion window which has one or more arguments, the editor highlights the first argument and displays a tooltip suggesting the format for this argument. To move to the next argument, press the  `Tab`  or  `Enter`  keys.
+For example, when you select a method from the code completion window which has one or more arguments, the editor highlights the first argument and displays a tooltip suggesting the format for this argument. To move to the next argument, press the  kbd:[Tab]  or  kbd:[Enter]  keys.
 
 You can invoke the tooltips with method parameters by pressing:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Ctrl-P`
-|*macOS*(TM) |`Command-P`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+P]
+|*macOS*(TM) |kbd:[Command+P]
 |===
 
 or, selecting *Source > Show Method Parameters* from the menu bar at any time.
@@ -254,13 +256,13 @@ image::images/parameter.png[]
 
 === Common Prefix Completion
 
-You can use the  `Tab`  key to quickly fill in the most commonly used prefixes and single suggestions. To check out how this feature works, try typing the following:
+You can use the  kbd:[Tab] key to quickly fill in the most commonly used prefixes and single suggestions. To check out how this feature works, try typing the following:
 
 Type  `System.out.p`  and wait for code completion to show all fields and methods that start with "p". All the suggestions will be related to "print".
 
 image::images/prefixcompletion.png[]
 
-Press the  `Tab`  key and the editor automatically fills in the "print". You can continue and type "l" and, after pressing `Tab` again, "println" will be added.
+Press the  kbd:[Tab]  key and the editor automatically fills in the "print". You can continue and type "l" and, after pressing kbd:[Tab] again, "println" will be added.
 
 //==============================================================================
 
@@ -272,7 +274,7 @@ image::images/subcompletion.png[]
 
 To implement this feature, select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Editor > Code Completion
 |*macOS*(TM) |NetBeans > Preferences... > Editor > Code Completion
@@ -286,7 +288,7 @@ You can then type part of the method you want to call, in this case `prop`, then
 
 === Chain Completion
 
-When you need to type a chain of commands, you can use code completion. By  pressing  `Ctrl-Space`  twice all available chains will be shown. The editor scans: variables, fields, and methods that are in the visible context. It will then suggest a chain that satisfies the expected type.
+When you need to type a chain of commands, you can use code completion. By  pressing  kbd:[Ctrl+Space]  twice all available chains will be shown. The editor scans: variables, fields, and methods that are in the visible context. It will then suggest a chain that satisfies the expected type.
 
 image::images/chain.png[]
 
@@ -295,13 +297,13 @@ image::images/chain.png[]
 
 === Completion of Static Imports
 
-When you want to complete a statement and, at the same time, require to make use of a static import statement, use code completion. By pressing  `Ctrl-Space`  twice, all available static import statements will be shown.
+When you want to complete a statement and, at the same time, require to make use of a static import statement, use code completion. By pressing  kbd:[Ctrl+Space]  twice, all available static import statements will be shown.
 
 image::images/static.png[]
 
 If you would like static import statements to be added automatically, select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Editor > Formatting
 |*macOS*(TM) |NetBeans > Preferences... > Editor > Formatting
@@ -319,7 +321,7 @@ image::images/exclude2-small.png[]
 
 You can add or modify your exclusion rules either when "Configure excludes" is selected from the code completion list or, by selecting:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Editor > Code Completion
 |*macOS*(TM) |NetBeans > Preferences... > Editor > Code Completion
@@ -353,20 +355,20 @@ When a non-imported class is found, the image:images/bulberror1.png[] error mark
 
 While you are typing, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Ctrl-Shift-I`
-|*macOS*(TM) |`Command-Shift-I`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+Shift+I]
+|*macOS*(TM) |kbd:[Command+Shift+I]
 |===
 
 or, choose *Source > Fix Imports* from the menu bar or, right-click and choose *Source > Fix Imports*, to add all missing import statements and, remove all unused import statements at once.
 
 To add an import only for the type at which the cursor is located, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Alt-Shift-I`
-|*macOS*(TM) |`Ctrl-Shift-I`
+|*Windows*(TM)/*Linux* |kbd:[Alt+Shift+I]
+|*macOS*(TM) |kbd:[Ctrl+Shift+I]
 |===
 
 image::images/imports2.png[]
@@ -385,7 +387,7 @@ To quickly see if your code contains unused or missing imports, watch the error 
 
 You can specify that, whenever you save a file, all the unused imports should automatically be removed, select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Select Tools > Options > Editor > On Save
 |*macOS*(TM) |NetBeans > Preferences... > Editor > On Save
@@ -407,10 +409,10 @@ When working in the Java editor, you can generate pieces of code in one of two w
 
 In the editor, you can automatically generate: various constructs, whole methods, override and delegate methods, add properties and more. To invoke code generation, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* | `Alt-Insert`
-|*macOS*(TM) |`Ctrl-I`
+|*Windows*(TM)/*Linux* |kbd:[Alt+Insert]
+|*macOS*(TM) |kbd:[Ctrl+I]
 |===
 
 or, choose *Source > Insert Code...* from the menu bar or, right-click and select *Insert Code...* anywhere in the editor to insert a construct from the Code Generation box. The suggested list is adjusted to the current context.
@@ -427,7 +429,7 @@ You can also generate code from the code completion window. In this example, we 
 
 image::images/codegeneration2.png[]
 
-Press `Ctrl-Space` to open the code completion window and choose the following item:  `ColorChooser(String name, int number) - generate`. The editor generates a constructor with the specified parameters.
+Press kbd:[Ctrl+Space] to open the code completion window and choose the following item:  `ColorChooser(String name, int number) - generate`. The editor generates a constructor with the specified parameters.
 
 In the code completion window, the constructors that can be generated automatically  are marked with the image:images/newconstructor.png[] icon and the " `generate` " note.
 
@@ -455,7 +457,7 @@ You can use code templates by selecting one from the code completion window or,
 by typing its abbreviation, found by selecting:
 
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Editor > Code Templates
 |*macOS*(TM) |NetBeans > Preferences... > Editor > Code Templates
@@ -463,7 +465,7 @@ by typing its abbreviation, found by selecting:
 
 and then *Language: Java* in the *Code Templates* pane.
 
-The template can be expanded by pressing the default expansion key  `Tab`. In the expanded template, editable parts are displayed as blue boxes. Use the  `Tab` key again to go through the parts that you need to edit.
+The template can be expanded by pressing the default expansion key  kbd:[Tab]. In the expanded template, editable parts are displayed as blue boxes. Use the  kbd:[Tab] key again to go through the parts that you need to edit.
 
 //==============================================================================
 
@@ -471,7 +473,7 @@ The template can be expanded by pressing the default expansion key  `Tab`. In th
 
 To add or edit code templates, select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Editor > Code Templates
 |*macOS*(TM) |NetBeans > Preferences... > Editor > Code Templates
@@ -481,7 +483,7 @@ then select *Language: Java*. In the *Templates:* window you will be pesented wi
 
 Use the *New* and *Remove* buttons to modify the templates list. To edit an existing template, select the template and edit the code in the *Expanded Text* field. Then ideally, you should add a *Description* as an aid memoir and, if necessary, a *Context*.
 
-Choose your peferred key from the *Expand Template on:* list, to activate your template. The default key is  `Tab` . Finally, select an action from the *On Template Expansion:* list.
+Choose your peferred key from the *Expand Template on:* list, to activate your template. The default key is  kbd:[Tab] . Finally, select an action from the *On Template Expansion:* list.
 
 See link:../php/code-templates.html[+Code Templates in NetBeans IDE for PHP+], for more information about templates.
 
@@ -499,10 +501,10 @@ Use the following features to facilitate working with Javadoc for your code.
 
 To display Javadoc, place the cursor on an element in your code and, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* | `Ctrl-Shift-Space`
-|*macOS*(TM) |`Command-Shift-\`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+Shift+Space]
+|*macOS*(TM) |kbd:[Command+Shift+{backslash}]
 |===
 
 or choose *Source > Show Documentation* from the menu bar. The Javadoc for this element is displayed in a popup window.
@@ -515,7 +517,7 @@ From the menu bar, select *Window > IDE Tools > Javadoc Documentation* to open t
 
 === Creating Javadoc Stubs
 
-Place the cursor above a method or a class that has no Javadoc, type  `"/**` ", and press  `Enter` .
+Place the cursor above a method or a class that has no Javadoc, type  `"/**` ", and press  kbd:[Enter] .
 
 image::images/javadoc1.png[]
 
@@ -531,7 +533,7 @@ image::images/javadoc2.png[]
 
 If you do not want to see the hints related to Javadoc, select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Editor > Hints
 |*macOS*(TM) |NetBeans > Preferences... > Editor > Hints
@@ -547,7 +549,7 @@ Code completion is available for Javadoc tags.
 
 image::images/javadoc3.png[]
 
-Type the `@` symbol and wait until the code completion window opens, depending on your settings, you may need to press  `Ctrl-Space`. Then select the required tag from the drop-down list.
+Type the `@` symbol and wait until the code completion window opens, depending on your settings, you may need to press  kbd:[Ctrl+Space]. Then select the required tag from the drop-down list.
 
 //==============================================================================
 
@@ -593,10 +595,10 @@ For the most common coding mistakes, you can see hints in the left-hand margin o
 
 Hints are displayed automatically by default. However, if you want to view all hints, choose *Source > Fix Code* from the menu bar or, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Alt-Enter`
-|*macOS*(TM) |`Ctrl-Enter`
+|*Windows*(TM)/*Linux* |kbd:[Alt+Enter]
+|*macOS*(TM) |kbd:[Ctrl+Enter]
 |===
 
 For example, try typing `myBoolean=true`. The editor detects that this variable is not defined. Click the hint icon image:images/bulberror1.png[] and, see the editor suggests that you create a field, a method parameter, or a local variable.
@@ -612,10 +614,10 @@ You can easily surround pieces of your code with various statements, such as  `f
 Select a block in your code that you want to surround with a statement and click the bulb icon image:images/bulb.png[] in the left-hand margin or, choose *Source > Fix Code* from the menu bar or, press:
 
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Alt-Enter`
-|*macOS*(TM) |`Ctrl-Enter`
+|*Windows*(TM)/*Linux* |kbd:[Alt+Enter]
+|*macOS*(TM) |kbd:[Ctrl+Enter]
 |===
 
 The editor displays a pop-up list of suggestions from which you can select the statement you need.
@@ -628,7 +630,7 @@ image::images/surroundwith.png[]
 
 You might want to limit the number of categories for which hints are displayed. To do this, select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Editor > Hints
 |*macOS*(TM) |NetBeans > Preferences... > Editor > Hints
@@ -660,7 +662,7 @@ The IDE provides several preset coloring schemes, which are called profiles. You
 
 To customize semantic coloring settings for the Java editor, select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options > Fonts & Colors
 |*macOS*(TM) |NetBeans > Preferences... > Fonts & Colors
@@ -683,7 +685,7 @@ NOTE: All NetBeans IDE settings and profiles are stored in the _NetBeans userdir
 
 To export IDE settings, select:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
 |*Windows*(TM)/*Linux* |Tools > Options
 |*macOS*(TM) |NetBeans > Preferences...
@@ -721,7 +723,7 @@ The IDE highlights usages of the same element, matching braces, method exit poin
 
 If you place the cursor in an element, such as a field or a variable, all usages of this element are highlighted. Note that error stripes in the editor's righthand margin indicate the usages of this element in the entire source file, see: <<Error Stripes>>. Click the error stripe to quickly navigate to the desired usage location.
 
-If you decide to rename all the highlighted instances, use the Instant Rename command (Ctrl-R or choose Refactor > Rename).
+If you decide to rename all the highlighted instances, use the Instant Rename command (kbd:[Ctrl+R] or choose Refactor > Rename).
 
 //===================================== Semantic Coloring and Highlighting (End)
 
@@ -749,20 +751,20 @@ Select: a class, method or field in your code and then choose your desired actio
 
 *Go to declaration*, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Ctrl-B`
-|*macOS*(TM) |`Ctrl-Shift-G`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+B]
+|*macOS*(TM) |kbd:[Ctrl+Shift+G]
 |===
 
 or, select *Navigate > Go to Declaration* from the menu bar or, right-click and select *Navigate > Go To Declaration* from the pop-up menu. The editor then moves the cursor to its declaration within: the current file or, if not there opens the appropriate file and positions the cursor to the declaration of your selected item.
 
 *Go to source*, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Ctrl-Shift-B`
-|*macOS*(TM) |`Command-Shift-B`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+Shift+B]
+|*macOS*(TM) |kbd:[Command+Shift+B]
 |===
 
 or, select *Navigate > Go to Source* from the menu bar or, right-click and select *Navigate > Go to Source* from the pop-up menu. The result of this action is similar to that of "go to declaration". However, in this case it opens the file of the original "source declaration".
@@ -773,10 +775,10 @@ If you know the name of the type (class, interface, annotation or enum), file, o
 
 *Go to type*, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Ctrl-O`
-|*macOS*(TM) |`Command-O`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+O]
+|*macOS*(TM) |kbd:[Command+O]
 |===
 
 or, select *Navigate > Go to Type...* from the menu bar.
@@ -785,25 +787,25 @@ image::images/gototype.png[]
 
 *Go to file*, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Alt-Shift-O`
-|*macOS*(TM) |`Ctrl-Shift-O`
+|*Windows*(TM)/*Linux* |kbd:[Alt+Shift+O]
+|*macOS*(TM) |kbd:[Ctrl+Shift+O]
 |===
 
 or, select *Navigate > Go to File...* from the menu bar.
 
 *Go to symbol*, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Ctrl-Alt-Shift-O`
-|*macOS*(TM) |`Ctrl-Shift-Command-O`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+Alt+Shift+O]
+|*macOS*(TM) |kbd:[Ctrl+Shift+Command+O]
 |===
 
 or, select *Navigate > Go to Symbol...* from the menu bar.
 
-*Go to line*, press `Ctrl-G` or, select *Navigate > Go to Line* from the menu bar, and enter the line number to which you want to jump.
+*Go to line*, press kbd:[Ctrl+G] or, select *Navigate > Go to Line* from the menu bar, and enter the line number to which you want to jump.
 
 image::images/gotoline.png[]
 
@@ -811,7 +813,7 @@ image::images/gotoline.png[]
 
 === Jumping to Last Edit
 
-To quickly return to your last edit, even if it is in another file or project, press `Ctrl-Q` or use the button in the top left corner of the Java editor toolbar. The last edited document opens, and the cursor is at the position, which you edited last.
+To quickly return to your last edit, even if it is in another file or project, press kbd:[Ctrl+Q] or use the button in the top left corner of the Java editor toolbar. The last edited document opens, and the cursor is at the position, which you edited last.
 
 image::images/jumplastedit.png[]
 
@@ -833,20 +835,20 @@ There are several features that allow you to switch between open files:
 
 To go to a previously edited file, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Alt-Left`
-|*macOS*(TM) |`Ctrl-Left`
+|*Windows*(TM)/*Linux* |kbd:[Alt+Left]
+|*macOS*(TM) |kbd:[Ctrl+Left]
 |===
 
 or, select *Navigate > Back*, from the menu bar.
 
 To move forward press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Alt-Right`
-|*macOS*(TM) |`Ctrl-Right`
+|*Windows*(TM)/*Linux* |kbd:[Alt+Right]
+|*macOS*(TM) |kbd:[Ctrl+Right]
 |===
 
 or, select *Navigate > Forward*, from the menu bar.
@@ -855,13 +857,13 @@ Alternatively, you can press the corresponding buttons on the editor toolbar, se
 
 image::images/jumprecentfile.png[]
 
-* You can toggle between files and windows by pressing `Ctrl-Tab`. After you press `Ctrl-Tab`, a pop-up window opens containg two panes: the left-hand pane shows a list of all open files and, the right-hand pane shows a list of all windows. Hold down the `Ctrl` key then press and release the `Tab` key to move forward  through the list. Hold down `Ctrl-Shift` then press and release the `Tab` key to move backward through the list. When your required file is highlighted release all keys to switch to that file.
+* You can toggle between files and windows by pressing kbd:[Ctrl+Tab]. After you press kbd:[Ctrl+Tab], a pop-up window opens containg two panes: the left-hand pane shows a list of all open files and, the right-hand pane shows a list of all windows. Hold down the kbd:[Ctrl] key then press and release the kbd:[Tab] key to move forward  through the list. Hold down kbd:[Ctrl+Shift] then press and release the kbd:[Tab] key to move backward through the list. When your required file is highlighted release all keys to switch to that file.
 
-NOTE: If you continue pressing the `Tab` key you will also cycle through the windows list as well.
+NOTE: If you continue pressing the kbd:[Tab] key you will also cycle through the windows list as well.
 
 image::images/togglefile.png[]
 
-* You can show all open documents by pressing, `Shift-F4` or, select *Windows > Documents...* from the menu bar. After you have selected the *Documents* window, all open files are shown. Order the files based on your needs and choose the file you would like to open.
+* You can show all open documents by pressing, kbd:[Shift+F4] or, select *Windows > Documents...* from the menu bar. After you have selected the *Documents* window, all open files are shown. Order the files based on your needs and choose the file you would like to open.
 
 image::images/shift-f4.png[]
 
@@ -871,10 +873,10 @@ image::images/shift-f4.png[]
 
 You can use bookmarks to quickly navigate to specific places in your code. To create a bookmark, place the cursor anywhere in a line of code and, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Ctrl-Shift-M`
-|*macOS*(TM) |`Command-Shift-M`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+Shift+M]
+|*macOS*(TM) |kbd:[Command+Shift+M]
 |===
 
 or, select *Navigate > Toggle Bookmark* from the menu bar or, right-click the left margin and choose *Bookmark > Toggle Bookmark*.
@@ -891,25 +893,25 @@ To clear all document bookmarks, you need to customize the Toolbar, to do this s
 
 To go to the next bookmark, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Ctrl-Shift-Period`
-|*macOS*(TM) |`Command-Shift-Period`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+Shift+.]
+|*macOS*(TM) |kbd:[Command+Shift+.]
 |===
 
 To go to the previous bookmark, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Ctrl-Shift-Comma`
-|*macOS*(TM) |`Command-Shift-Comma`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+Shift+,]
+|*macOS*(TM) |kbd:[Command+Shift+,]
 |===
 
 Automatically a pop-up list of bookmarks appears containing all the bookmarks visited in your current session, including those files that are not currently open in the editor.
 
 image::images/bookmark2.png[]
 
-You can move forward or backward by repeatedly releasing and pressing the `Period` key or `Comma` key as appropriate to highlight your chosen bookmark. Then when you release the whole key combination the cursor is moved to the bookmark in your code.
+You can move forward or backward by repeatedly releasing and pressing the kbd:[.] key or kbd:[,] key as appropriate to highlight your chosen bookmark. Then when you release the whole key combination the cursor is moved to the bookmark in your code.
 
 If the file is not the topmost, the editor will switch to that file and move the cursor to the selected bookmark. Selecting a bookmark in a closed file will cause the editor to open that file and position the cursor at the required bookmark.
 
@@ -919,7 +921,7 @@ image::images/bookmark3-small.png[]
 
 The *Bookmarks* window contains two panes: one showing all visited bookmarks in the current session and, the other a view of the code related to the currently highlighted bookmark. You cannot edit anything in this window, it is there so that you can see if the correct bookmark has been selected in the bookmarks pane.
 
-In the bookmarks pane you can select either a *Tree View* or, a *Table View*. In *Table View* you can assign keys and labels to bookmarks, so that when  `Ctrl-G`  is pressed, you can quickly jump to a labelled bookmark in your code.
+In the bookmarks pane you can select either a *Tree View* or, a *Table View*. In *Table View* you can assign keys and labels to bookmarks, so that when  kbd:[Ctrl+G]  is pressed, you can quickly jump to a labelled bookmark in your code.
 
 //==============================================================================
 
@@ -931,9 +933,9 @@ image::images/navigatorwindow.png[]
 
 To open the Navigator window, choose *Window > Navigator* or, press:
 
-[grid="none",frame="none",width="75%",cols="1,4"]
+[cols="1,4"]
 |===
-|*Windows*(TM)/*Linux* |`Ctrl-7`
+|*Windows*(TM)/*Linux* |kbd:[Ctrl+7]
 |===
 
 NOTE: There is no keyboard shortcut set for |*macOS*(TM). See *Customizing Keyboard Shortcuts* to learn how to set missing shortcuts.


### PR DESCRIPTION
Turned on the :experimental: feature Asciidoctor to allow key combinations to appear as graphics.
Fixed table widths causing whitespace issues with the table of contents. Was set to a width of 75%, which is now removed on all tables.