### PR TITLE
Fix "boostraping" typo

### DIFF
--- a/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
+++ b/netbeans.apache.org/src/content/participate/submit-pr.asciidoc
@@ -62,7 +62,7 @@ link:/participate/build-run-debug-tutorials.html[Watch a series of 5 short video
 
 == Contributing to Apache NetBeans in GitHub
 
-=== Boostraping (do this once)
+=== Bootstrapping (do this once)
 
 Since you don't have write permissions to the GitHub apache mirror, you need to
 fork https://github.com/apache/incubator-netbeans in GitHub, this is done using


### PR DESCRIPTION
This just fixes a typo in the "Submitting PRs" page.

This is a rebased version of #86.