### PR TITLE
Creating download page for maven artefacts sources

### DIFF
--- a/netbeans.apache.org/build.gradle
+++ b/netbeans.apache.org/build.gradle
@@ -67,7 +67,7 @@ task preprocessContentAssets(type: Copy,
         "**/*.jpeg", "**/*.jpg",
         "**/*.svg", "**/*.ttf",
         "**/*.woff", "**/.htaccess",
-        "fonts/**"
+        "fonts/**","**/*.cgi"
     
     exclude "/templates/**"
 }

--- a/netbeans.apache.org/src/content/download/maven/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/maven/index.asciidoc
@@ -1,0 +1,86 @@
+////
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+////
+////
+
+NOTE: 
+See https://www.apache.org/dev/release-download-pages.html 
+for important requirements for download pages for Apache projects.
+
+////
+= Apache NetBeans Releases
+:jbake-type: page
+:jbake-tags: download
+:jbake-status: published
+:keywords: Apache NetBeans releases
+:description: Apache NetBeans Releases Page
+:toc: left
+:toc-title:
+:linkattrs:
+
+== Mirror selection
+////
+  use  raw html to epalce bracket items with apache mirror with the cgi script
+////
+++++
+<p>
+[if-any logo]
+   <a href="[link]"><img align="right" src="[logo]" border="0" alt="logo"/></a>
+[end]
+
+The currently selected mirror is <b>[preferred]</b>.
+If you encounter a problem with this mirror,please select another mirror.
+If all mirrors are failing, there are <i>backup</i> mirrors (at the end of the mirrors list) that should be available.
+</p>
+
+        <form action="[location]" method="get" id="SelectMirror">
+          Other mirrors:
+          <select name="Preferred">
+            [if-any http]
+            [for http]
+            <option value="[http]">[http]</option>
+            [end]
+            [end]
+            [if-any ftp]
+            [for ftp]
+            <option value="[ftp]">[ftp]</option>
+            [end]
+            [end]
+            [if-any backup]
+            [for backup]
+            <option value="[backup]">[backup] (backup)</option>
+            [end]
+            [end]
+          </select>
+          <input type="submit" value="Change"/>
+        </form>
+
+<p>
+   You may also consult the <a href="https://www.apache.org/mirrors/">complete list of mirrors.</a>
+</p>
+
+++++
+
+== Apache NetBeans (incubating) parent pom 1 
+ 
+link:++[prefered]incubator/netbeans/incubating-netbeans-mavenutils/apache-netbeans-parent-1/incubating-apache-netbeans-parent-1-source-release.zip++[netbeans/incubating-nebeans-mavenutils/apache-netbeans-parent-1/incubating-apache-netbeans-parent-1-source-release.zip]
+
+
+== Others
+
+placeholder

--- a/netbeans.apache.org/src/content/download/maven/index.cgi
+++ b/netbeans.apache.org/src/content/download/maven/index.cgi
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Just call the standard mirrors.cgi script. It will use download.html
+# as the input template.
+exec /www/www.apache.org/dyn/mirrors/mirrors.cgi $*


### PR DESCRIPTION
Hi, this is a PR intended to put a cgi file that reintepret associated html page to allow mirror selection for download like in this page for Apache Maven 3.6.0
http://maven.apache.org/download.cgi?Preferred=http%3A%2F%2Fwwwftp.ciril.fr%2Fpub%2Fapache%2F

The resulting page will be there but I guess some configuration needs to be set with INFRA
https://netbeans.apache.org/download/maven/index.html

Regards
