### PR TITLE
Update htaccess for cgi script

### DIFF
--- a/netbeans.apache.org/src/content/.htaccess
+++ b/netbeans.apache.org/src/content/.htaccess
@@ -6,3 +6,5 @@ Redirect 302 /nb/updates/9.0/ http://netbeans-vm.apache.org/uc/9.0/
 Redirect 302 /nb/updates/10.0/ http://netbeans-vm.apache.org/uc/10.0/
 Redirect 302 /nb/issues_redirect.html https://issues.apache.org/jira/projects/NETBEANS/issues
 Redirect 302 /nb/report-issue https://issues.apache.org/jira/projects/NETBEANS/issues
+#cgi mirror script
+Redirect 301 /download/maven/index.html /download/maven/index.cgi


### PR DESCRIPTION
I hope the folder for redirect is good. 
http://netbeans.apache.org/download/maven/index.html should be redirected to redirectedhttp://netbeans.apache.org/download/maven/index.cgi