### PR TITLE
Add the note to report-issue.asciidoc

### DIFF
--- a/netbeans.apache.org/src/content/participate/report-issue.asciidoc
+++ b/netbeans.apache.org/src/content/participate/report-issue.asciidoc
@@ -29,3 +29,16 @@ If you have found a bug in the application, please help Apache NetBeans by repor
 
 Thank you for helping us make Apache NetBeans better!
 
+== Note
+
+Please provide the following information to reproduce your issues when you submit them.
+
+- Example code (Attachments or Description)
+- Example project (Attachments)
+- Screenshots (Attachments)
+- Exact steps e.g. 1. Create an empty project, 2. Write the following code, 3. Something... (Description)
+- Actual results (Description)
+- Expected results (Description)
+- NetBeans version (Affects Version/s)
+- JDK version (Environment)
+- OS (Environment)


### PR DESCRIPTION
Sometimes information is missing from issue reporters. So I think that we should add the note to the "Reporting issues" page.