### PR TITLE
link to mailing list thread about Java EE 8 support

### DIFF
--- a/netbeans.apache.org/src/content/download/nb110/index.asciidoc
+++ b/netbeans.apache.org/src/content/download/nb110/index.asciidoc
@@ -173,7 +173,7 @@ and we have included this cluster in Apache NetBeans 11.0.
 
 This means that you can now build JavaEE applications with Ant, Maven or Gradle projects. 
 
-NOTE: Explicit support of Java EE 8 is not currently part of Apache NetBeans 11.0.  Also, JavaEE 8
+NOTE: Explicit support of Java EE 8 is link:https://lists.apache.org/thread.html/f53f087e4aee0f6b52872a9b9789e69d2d6011fce3df7952bcb7223d@%3Cusers.netbeans.apache.org%3E[not currently part] of Apache NetBeans 11.0.  Also, JavaEE 8
 only runs on JDK 8, not on later releases, and so if you 're doing development with JavaEE 8 it's
 best to run NetBeans itself on JDK 8.
 


### PR DESCRIPTION
I looked for a JIRA issue about Java EE 8 support but I couldn't find one so I'm linking to @juneau001 's post on the mailing list. On Java Off Heap I heard him say he's working on Java EE 8 support. Thanks!!