### PR TITLE
htaccess redirect to legacy netbeans.org

### DIFF
--- a/netbeans.apache.org/src/content/.htaccess
+++ b/netbeans.apache.org/src/content/.htaccess
@@ -9,3 +9,13 @@ Redirect 302 /nb/issues_redirect.html https://issues.apache.org/jira/projects/NE
 Redirect 302 /nb/report-issue https://issues.apache.org/jira/projects/NETBEANS/issues
 #cgi mirror script
 Redirect 301 /download/maven/index.html /download/maven/index.cgi
+# Enable rewrite engine to redirect 404 pages to old netbeans.org (137.254.56.26)
+RewriteEngine On
+# If the requested stuff is not a file ...
+RewriteCond "%{REQUEST_FILENAME}" "!-f"
+# ... nor a directory ...
+RewriteCond "%{REQUEST_FILENAME}" "!-d"
+# ... then redirect (302) to Oracle's server
+RewriteRule (.*) "http://137.254.56.26/$1" [L,R=302]
+# As a fallaback also redirect all 404 files
+ErrorDocument 404 http://137.254.56.26/%{REQUEST_URI}


### PR DESCRIPTION
This should redirect all not found pages to legacy netbeans.org. Let's see if this works.