### PR TITLE
Generic Netbeans version

### DIFF
--- a/netbeans.apache.org/src/content/plugins/index.asciidoc
+++ b/netbeans.apache.org/src/content/plugins/index.asciidoc
@@ -30,7 +30,7 @@ The NetBeans IDE and the NetBeans Platform are built on top of a modular archite
 
 We are currently transitioning the plugin portal to the new Apache infrastructure. Some plugins won't be able to be hosted in Apache infrastructure due to licensing issues.
 
-Apache NetBeans 9.0 Beta uses the same update center as in previous versions, so you should be able to install plugins (hosted outside the Apache infrastructure) designed for previous versions of NetBeans. You will be asked to accept the appropriate license agreement for any plugins you install.
+Apache NetBeans uses the same update center as in previous versions, so you should be able to install plugins (hosted outside the Apache infrastructure) designed for previous versions of NetBeans. You will be asked to accept the appropriate license agreement for any plugins you install.
 
 Please visit the previous link:http://plugins.netbeans.org/PluginPortal/[NetBeans Plugin Portal] for more information about NetBeans plugins.
 


### PR DESCRIPTION
Update to mention only Apache Netbeans, as plugins are not limited to 9.0 Beta, or any other specific version - unless the plugin itself mentions it, which then would be outside the scope of the information on this page in particular.
Might be better than to say Netbeans 9.0+, as any version under the Apache name already implies such.