### PR TITLE
[NETBEANS-2429] Adding dtds to netbeans.apache.org

### DIFF
--- a/netbeans.apache.org/build.gradle
+++ b/netbeans.apache.org/build.gradle
@@ -63,6 +63,7 @@ task preprocessContentAssets(type: Copy,
     includeEmptyDirs false
     
     include "**/*.js", "**/.css", "**/css/*.css", 
+        "dtds/**",
         "**/*.png", "**/*.gif",
         "**/*.jpeg", "**/*.jpg",
         "**/*.svg", "**/*.ttf",

--- a/netbeans.apache.org/src/content/dtds/EditorAbbreviations-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/EditorAbbreviations-1_0.dtd
@@ -1,0 +1,40 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+
+This is DTD for Editor's abbreviations options file.
+
+Public ID: "-//NetBeans//DTD Editor Abbreviations settings 1.0//EN"
+System ID: https://netbeans.org/dtds/EditorAbbreviations-1_0.dtd
+
+-->
+
+
+
+<!ELEMENT abbrevs (abbrev*)>
+
+<!ELEMENT abbrev (#PCDATA)>
+<!ATTLIST abbrev
+    key CDATA #REQUIRED
+    remove (true|false) "false" 
+    action CDATA #IMPLIED
+    xml:space (default|preserve) 'preserve'
+>

--- a/netbeans.apache.org/src/content/dtds/EditorCodeTemplates-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/EditorCodeTemplates-1_0.dtd
@@ -1,0 +1,79 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+    Created on : June 9, 2007, 5:37 PM
+    Author     : vstejskal
+    Description:
+        The vocabulary for an editor code templates settings file.
+
+    PUBLIC ID  : -//NetBeans//DTD Editor Code Templates settings 1.0//EN
+    SYSTEM ID  : https://netbeans.org/dtds/EditorCodeTemplates-1_0.dtd
+-->
+
+
+
+<!ELEMENT codetemplates ( codetemplate )* >
+<!ATTLIST codetemplates>
+
+<!--
+    abbreviation:  (String, required) Shortcut text that you type in
+                   the editor to expand your code template.
+    descriptionId: (String) A resource bundle key with description text for
+                   this code template. Modules are encouraged to use this
+                   instead of <description/> element to make their templates
+                   localizable.
+    contexts:      (String) The list of comma separated contexts for filtering
+                   templates offered in code completion. Presently this is only
+                   used by java module, which registers its own CodeTemplateFilter.Factory.
+    uuid:          (String) An id that uniquely identifies this template. If you
+                   provide one for your template make sure it is a real unique id.
+    remove:        When 'true' this code template will be removed and all its
+                   optional attributes and elements will be ignored.
+-->
+<!ELEMENT codetemplate ( code?, description? ) >
+<!ATTLIST codetemplate
+          abbreviation      CDATA #REQUIRED
+          descriptionId     CDATA #IMPLIED
+          contexts          CDATA #IMPLIED
+          uuid              CDATA #IMPLIED
+          remove            ( true | false ) "false"
+          xml:space         ( default | preserve ) "default"
+>
+
+<!--
+    Contains the actual code of the code template. In API this is also called
+    parametrized text. It should be raw text enclosed in <![CDATA[ ]]> section.
+    No character translation is done when loading the code text (eg. pipe '|'
+    characters are left alone). See editor/codetemplates module's documentation
+    for the list of supported parameters (eg. ${cursor} for positioning the caret).
+-->
+<!ELEMENT code ( #PCDATA ) >
+<!ATTLIST code>
+
+<!--
+    Contains description for a code template in form of raw text enclosed in
+    <![CDATA[ ]]> section. This is designed for users custom code templates or
+    when they change description provided by a module. The modules should use
+    'descriptionId' attribute instead.
+-->
+<!ELEMENT description ( #PCDATA ) >
+<!ATTLIST description>
+

--- a/netbeans.apache.org/src/content/dtds/EditorFontsColors-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/EditorFontsColors-1_0.dtd
@@ -1,0 +1,52 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+
+This is DTD for Editor's Fonts & Colors options file.
+
+Public ID: "-//NetBeans//DTD Editor Fonts and Colors settings 1.0//EN"
+System ID: https://netbeans.org/dtds/EditorFontsColors-1_0.dtd
+
+-->
+
+
+    <!ELEMENT fontscolors (fontcolor*, elementcolor*)>
+
+    <!ELEMENT fontcolor (font?)>
+    <!ATTLIST fontcolor
+         syntaxName CDATA #REQUIRED
+         foreColor CDATA #IMPLIED
+         bgColor CDATA #IMPLIED
+    >
+
+    <!ELEMENT font EMPTY> 
+    <!ATTLIST font 
+         name CDATA #IMPLIED
+         size CDATA #IMPLIED
+         style CDATA #IMPLIED
+    > 
+
+    <!ELEMENT elementcolor EMPTY>
+    <!ATTLIST elementcolor
+         name CDATA #REQUIRED
+         color CDATA #REQUIRED
+    >
+

--- a/netbeans.apache.org/src/content/dtds/EditorFontsColors-1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/EditorFontsColors-1_1.dtd
@@ -1,0 +1,55 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+    Created on : November 6, 2006, 6:48 PM
+    Author     : vstejskal
+    Description:
+        The vocabulary for an editor fonts and colors settings file.
+
+    PUBLIC ID  : -//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN
+    SYSTEM ID  : https://netbeans.org/dtds/EditorFontsColors-1_1.dtd
+-->
+
+<!ELEMENT fontscolors ( fontcolor )* >
+<!ATTLIST fontscolors >
+
+
+<!ELEMENT fontcolor ( font? ) >
+<!ATTLIST fontcolor
+          name              CDATA #REQUIRED
+          bgColor           CDATA #IMPLIED
+          foreColor         CDATA #IMPLIED
+          underline         CDATA #IMPLIED
+          strikeThrough     CDATA #IMPLIED
+          waveUnderlined    CDATA #IMPLIED
+          default           CDATA #IMPLIED
+>
+
+
+<!--
+    The style attribute can be 'plain', 'bold', 'italic' or 'bold+italic'.
+-->
+<!ELEMENT font EMPTY>
+<!ATTLIST font
+          name          CDATA #IMPLIED
+          size          CDATA #IMPLIED
+          style         CDATA "plain"
+>

--- a/netbeans.apache.org/src/content/dtds/EditorKeyBindings-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/EditorKeyBindings-1_0.dtd
@@ -1,0 +1,39 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+
+This is DTD for Editor's keybindings options file.
+
+Public ID: "-//NetBeans//DTD Editor KeyBindings settings 1.0//EN"
+System ID: https://netbeans.org/dtds/EditorKeyBindings-1_0.dtd
+
+-->
+
+
+<!ELEMENT bindings (bind*)>
+
+<!ELEMENT bind EMPTY>
+<!ATTLIST bind
+    key CDATA #REQUIRED
+    remove (true|false) "false" 
+    actionName CDATA #IMPLIED
+>
+

--- a/netbeans.apache.org/src/content/dtds/EditorKeyBindings-1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/EditorKeyBindings-1_1.dtd
@@ -1,0 +1,42 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+    Created on : November 6, 2006, 6:48 PM
+    Author     : vstejskal
+    Description:
+        The vocabulary for an editor key bindings settings file.
+
+    PUBLIC ID  : -//NetBeans//DTD Editor KeyBindings settings 1.1//EN
+    SYSTEM ID  : https://netbeans.org/dtds/EditorKeyBindings-1_1.dtd
+-->
+
+<!ELEMENT bindings ( bind )* >
+<!ATTLIST bindings >
+
+<!--
+    The attribute 'actionName' must be specified when remove is false (or not specified).
+-->
+<!ELEMENT bind EMPTY >
+<!ATTLIST bind
+          key           CDATA #REQUIRED
+          actionName    CDATA #IMPLIED
+          remove        ( true | false ) "false"
+>

--- a/netbeans.apache.org/src/content/dtds/EditorMacros-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/EditorMacros-1_0.dtd
@@ -1,0 +1,39 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+
+This is DTD for Editor's macros options file.
+
+Public ID: "-//NetBeans//DTD Editor Macros settings 1.0//EN"
+System ID: https://netbeans.org/dtds/EditorMacros-1_0.dtd
+
+-->
+
+
+<!ELEMENT macros (macro*)>
+
+<!ELEMENT macro (#PCDATA)>
+<!ATTLIST macro
+    name CDATA #REQUIRED
+    remove (true|false) "false"
+    xml:space (default|preserve) 'preserve'
+>
+

--- a/netbeans.apache.org/src/content/dtds/EditorMacros-1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/EditorMacros-1_1.dtd
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+    Created on : November 30, 2007, 2:58 PM
+    Author     : vstejskal
+    Description:
+        The vocabulary for an editor macros settings file.
+
+    PUBLIC ID  : -//NetBeans//DTD Editor Macros settings 1.1//EN
+    SYSTEM ID  : https://netbeans.org/dtds/EditorMacros-1_1.dtd
+-->
+
+
+
+<!ELEMENT editor-macros ( macro )* >
+<!ATTLIST macros>
+
+<!--
+    name:          (String, required) The name of this macro.
+    descriptionId: (String) A resource bundle key with description text for
+                   this macro. Modules are encouraged to use this
+                   instead of <description/> element to make their macros
+                   localizable.
+    remove:        When 'true' this macro will be removed and all its
+                   optional attributes and elements will be ignored.
+-->
+<!ELEMENT macro ( code?, description?, shortcut? ) >
+<!ATTLIST macro
+          name              CDATA #REQUIRED
+          descriptionId     CDATA #IMPLIED
+          remove            ( true | false ) "false"
+          xml:space         ( default | preserve ) "default"
+>
+
+<!--
+    Contains the actual code of this macro. It should be raw text enclosed in
+    <![CDATA[ ]]> section. No character translation is done when loading the code text.
+-->
+<!ELEMENT code ( #PCDATA ) >
+<!ATTLIST code>
+
+<!--
+    Contains macro's description in form of raw text enclosed in
+    <![CDATA[ ]]> section. This is designed for users custom macros or
+    when they change description provided by a module. Modules should use
+    'descriptionId' attribute instead.
+-->
+<!ELEMENT description ( #PCDATA ) >
+<!ATTLIST description>
+
+<!--
+    Defines keystrokes bound to the macro so that it can easily be played
+    from the editor.
+-->
+<!ELEMENT shortcut EMPTY>
+<!ATTLIST shortcut
+          keystrokes CDATA #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/EditorPreferences-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/EditorPreferences-1_0.dtd
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+    Created on : December 12, 2007, 2:51 PM
+    Author     : vstejskal
+    Description:
+        The vocabulary for an editor preferences file.
+
+    PUBLIC ID  : -//NetBeans//DTD Editor Preferences 1.0//EN
+    SYSTEM ID  : https://netbeans.org/dtds/EditorPreferences-1_0.dtd
+-->
+
+<!ELEMENT editor-preferences ( entry )* >
+<!ATTLIST editor-preferences >
+
+
+<!--
+    A single setting entry. Each setting is identified by its unique name and
+    has a value attached to it.
+    
+    name:       (String) A unique identifier of this setting.
+    
+    value:      (Any) The setting's value. In general editor preferences can have
+                values that are convertible to/from strings. The conversion methods
+                are those provided for primitive types in java. More specifically,
+                anything that can be get/set on java.util.prefs.Preferences can be
+                stored here. For other values the modules are required to provide
+                their own conversion to/from string and store the string value here.
+                
+                Please note, that only one from the 'value', 'valueId' attributes
+                or 'value' child element can be used.
+                
+    valueId:    (String) A resource bundle key that will be used for reading the
+                value for this setting. This is primarily designed for modules
+                that use localized setting values. User changes will always be
+                stored in the 'value' attribute or subelement.
+
+    javaType:   (String) Fully qualified name of a java class representing this
+                setting. This attribute is used purely for backwards compatibilty
+                reasons. If you are sure that all your clients and your own
+                code accesses this setting through MimeLookup and
+                java.util.prefs.Preferences then you don't need this.
+                
+    category:   (String) Determines the API stability of the setting. It can
+                be one of 'module' (the same as the API stability of a module declaring
+                this setting), 'private', 'deprecated'.
+                This attribute is ignored when loading settings, but should be
+                provided to indicate the availability of the setting for other
+                modules. If not specified or its value is not one of those listed
+                above the setting should be considered 'private'. Only modules that
+                'own' the setting should specify this attribute, if you are just supplying
+                value for a setting defined (owned) by somebody else do not specify this attribute. 
+
+    remove:     When 'true' this entry will be removed and all its
+                optional attributes and elements will be ignored.
+-->
+<!ELEMENT entry ( value? ) >
+<!ATTLIST entry
+          name              CDATA #REQUIRED
+          value             CDATA #IMPLIED
+          valueId           CDATA #IMPLIED
+          javaType          CDATA #IMPLIED
+          category          CDATA #IMPLIED
+          remove            ( true | false ) "false"
+          xml:space         ( default | preserve ) "default"
+>
+
+<!--
+    The value of a setting. If specified it should contain <![CDATA[...]]> section
+    with a value of the enclosing setting entry. If this is used the attributes
+    'value' and 'valueId' must not be specified.
+-->
+<!ELEMENT value ( #PCDATA ) >
+<!ATTLIST value >

--- a/netbeans.apache.org/src/content/dtds/EditorProperties-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/EditorProperties-1_0.dtd
@@ -1,0 +1,39 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+
+This is DTD for Editor's additional properties options file.
+
+Public ID: "-//NetBeans//DTD Editor Properties settings 1.0//EN"
+System ID: https://netbeans.org/dtds/EditorProperties-1_0.dtd
+
+-->
+
+
+<!ELEMENT properties (property*)>
+
+<!ELEMENT property EMPTY>
+<!ATTLIST property
+    name CDATA #REQUIRED
+    class CDATA #REQUIRED
+    value CDATA #REQUIRED
+>
+

--- a/netbeans.apache.org/src/content/dtds/EntityCatalog-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/EntityCatalog-1_0.dtd
@@ -1,0 +1,36 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- DEPRECATED; please use /xml/entities/ folder instead -->
+
+<!-- Optional namespace space prefix -->
+
+<!ENTITY % ns "">
+
+<!ENTITY % catalog "%ns;catalog">
+<!ENTITY % public "%ns;public">
+
+<!ELEMENT %catalog; (%public;)*>
+
+<!ELEMENT %public; EMPTY>
+<!ATTLIST %public;
+    publicId    CDATA #REQUIRED
+    uri         CDATA #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/KeymapPreferences-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/KeymapPreferences-1_0.dtd
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+    Created on : November 12, 2008, 11:41 AM
+    Author     : Max Sauer
+    Description:
+        The vocabulary for an keymap preferences file.
+
+    PUBLIC ID: -//NetBeans//DTD Keymap Preferences 1.0//EN
+    SYSTEM ID: https://netbeans.org/dtds/KeymapPreferences-1_0.dtd
+-->
+
+<!ELEMENT keymap-preferences (action)*>
+
+<!ELEMENT action (shortcut)*>
+<!ATTLIST action
+    id CDATA #IMPLIED
+  >
+
+<!ELEMENT shortcut EMPTY>
+<!ATTLIST shortcut
+    shortcut_string CDATA #IMPLIED
+  >

--- a/netbeans.apache.org/src/content/dtds/README.txt
+++ b/netbeans.apache.org/src/content/dtds/README.txt
@@ -1,0 +1,14 @@
+1. Please add entries to the file 'catalog' in this directory when
+   adding new DTDs. This will help people using various XML structure
+   editing tools to work with your kind of XML file offline. Do not
+   forget too that you can register a DTD for use inside the IDE (XML
+   module) using the xml/entities/ folder.
+
+2. Avoid editing existing DTDs. Consider making a new DTD instead
+   (just increment its number). This will help avoid confusion and
+   possible parse errors.
+
+3. See <http://openide.netbeans.org/versioning-policy.html#dtds> for
+   further hints.
+
+Comments, questions to nbdev@netbeans.org. -jglick

--- a/netbeans.apache.org/src/content/dtds/annotation-type-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/annotation-type-1_0.dtd
@@ -1,0 +1,62 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD annotation type 1.0//EN
+https://netbeans.org/dtds/annotation-type-1_0.dtd
+Document type declaration for AnnotationType.
+-->
+
+<!ELEMENT type (combination?)>
+<!ATTLIST type name CDATA #REQUIRED>
+
+<!ATTLIST type visible (true | false) #IMPLIED>
+<!-- The annotation is visible=true by default -->
+
+<!ATTLIST type localizing_bundle CDATA #IMPLIED>
+<!ATTLIST type description_key CDATA #IMPLIED>
+<!-- No localization/no description by defualt.
+   In fact, bundle/description is #REQUIRED for visible=true -->
+
+<!ATTLIST type glyph CDATA #IMPLIED>
+<!ATTLIST type highlight CDATA #IMPLIED>
+<!ATTLIST type foreground CDATA #IMPLIED>
+
+<!ATTLIST type type (line|linepart) #IMPLIED>
+<!-- The type=line by default -->
+
+<!ATTLIST type actions CDATA #IMPLIED>
+
+<!ELEMENT combination (combine+)>
+<!ATTLIST combination tiptext_key CDATA #IMPLIED>
+<!ATTLIST combination order CDATA #IMPLIED>
+<!ATTLIST combination min_optionals CDATA #IMPLIED>
+
+<!ELEMENT combine EMPTY>
+<!ATTLIST combine annotationtype CDATA #REQUIRED>
+
+<!ATTLIST combine absorb_all (true | false) #IMPLIED>
+<!-- The absorb_all=false by default -->
+
+<!ATTLIST combine optional (true | false) #IMPLIED>
+<!-- The optional=false by default -->
+
+<!ATTLIST combine min CDATA #IMPLIED>
+

--- a/netbeans.apache.org/src/content/dtds/annotation-type-1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/annotation-type-1_1.dtd
@@ -1,0 +1,91 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD annotation type 1.1//EN
+https://netbeans.org/dtds/annotation-type-1_1.dtd
+Document type declaration for AnnotationType.
+-->
+
+<!ELEMENT type (combination?)>
+<!ATTLIST type name CDATA #REQUIRED>
+
+<!ATTLIST type visible (true | false) #IMPLIED>
+<!-- The annotation is visible=true by default -->
+
+<!ATTLIST type localizing_bundle CDATA #IMPLIED>
+<!ATTLIST type description_key CDATA #IMPLIED>
+<!-- No localization/no description by defualt.
+   In fact, bundle/description is #REQUIRED for visible=true -->
+
+<!ATTLIST type glyph CDATA #IMPLIED>
+<!ATTLIST type highlight CDATA #IMPLIED>
+<!ATTLIST type foreground CDATA #IMPLIED>
+<!ATTLIST type waveunderline CDATA #IMPLIED>
+
+<!ATTLIST type type (line|linepart) #IMPLIED>
+<!-- The type=line by default -->
+
+<!ATTLIST type actions CDATA #IMPLIED>
+
+<!--Should a custom color be used when showing in the editor side bar (Error Stripe)?
+    default: true if custom_sidebar_color attribute is specified, false otherwise
+-->
+<!ATTLIST type use_custom_sidebar_color (true | false) #IMPLIED>
+
+<!--The custom color for the editor side bar (Error Stripe).
+    Valid values are 0xRRGGBB, where RR, GG, BB are hexadecimal numbers.
+    default: no color
+-->
+<!ATTLIST type custom_sidebar_color CDATA #IMPLIED>
+
+<!--Severity of the annotation. Used to recognize errors and warnings. If
+    none, the annotation is not visible in certain views (editor side bar).
+    default: none
+-->
+<!ATTLIST type severity (error | warning | ok | none) #IMPLIED>
+
+<!--Whether the annotation should be browseable by some kind "Show Next Error" action.
+    default: false
+-->
+<!ATTLIST type browseable (true | false) #IMPLIED>
+
+<!--Determines some "priority" of the annotation.
+    The smaller number, the higher priority.
+    default: 0
+-->
+<!ATTLIST type priority CDATA #IMPLIED>
+
+<!ELEMENT combination (combine+)>
+<!ATTLIST combination tiptext_key CDATA #IMPLIED>
+<!ATTLIST combination order CDATA #IMPLIED>
+<!ATTLIST combination min_optionals CDATA #IMPLIED>
+
+<!ELEMENT combine EMPTY>
+<!ATTLIST combine annotationtype CDATA #REQUIRED>
+
+<!ATTLIST combine absorb_all (true | false) #IMPLIED>
+<!-- The absorb_all=false by default -->
+
+<!ATTLIST combine optional (true | false) #IMPLIED>
+<!-- The optional=false by default -->
+
+<!ATTLIST combine min CDATA #IMPLIED>
+

--- a/netbeans.apache.org/src/content/dtds/attributes-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/attributes-1_0.dtd
@@ -1,0 +1,42 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD DefaultAttributes 1.0//EN -->
+<!-- XML representation of DefaultAttributes -->
+<!-- as for example a module layer. -->
+<!-- See: org.openide.filesystems.DefaultAttributes -->
+<!ELEMENT attributes (fileobject)*>
+<!ATTLIST attributes version CDATA #REQUIRED>
+<!ELEMENT fileobject (attr)*>
+<!ATTLIST fileobject name CDATA #REQUIRED>
+<!ELEMENT attr EMPTY>
+<!ATTLIST attr name CDATA #REQUIRED>
+<!ATTLIST attr bytevalue CDATA #IMPLIED>
+<!ATTLIST attr shortvalue CDATA #IMPLIED>
+<!ATTLIST attr intvalue CDATA #IMPLIED>
+<!ATTLIST attr longvalue CDATA #IMPLIED>
+<!ATTLIST attr floatvalue CDATA #IMPLIED>
+<!ATTLIST attr doublevalue CDATA #IMPLIED>
+<!ATTLIST attr boolvalue CDATA #IMPLIED>
+<!ATTLIST attr charvalue CDATA #IMPLIED>
+<!ATTLIST attr stringvalue CDATA #IMPLIED>
+<!ATTLIST attr methodvalue CDATA #IMPLIED>
+<!ATTLIST attr serialvalue CDATA #IMPLIED>
+<!ATTLIST attr urlvalue CDATA #IMPLIED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-catalog-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-catalog-1_0.dtd
@@ -1,0 +1,75 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Catalog 1.0//EN -->
+<!-- XML representation of Autoupdate Modules/Updates Catalog -->
+
+<!ELEMENT module_updates ((notification?, (module_group|module)*, license*)|error)>
+<!ATTLIST module_updates timestamp CDATA #REQUIRED>
+
+<!ELEMENT module_group ((module_group|module)*)>
+<!ATTLIST module_group name CDATA #REQUIRED>
+
+<!ELEMENT notification (#PCDATA)>
+<!ATTLIST notification url CDATA #IMPLIED>
+
+<!ELEMENT module (description?, module_notification?, external_package*, manifest)>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #REQUIRED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #REQUIRED
+                 needsrestart CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>
+
+<!ELEMENT error (auth_error|other_error)>
+
+<!ELEMENT auth_error EMPTY>
+
+<!ELEMENT other_error EMPTY>
+<!ATTLIST other_error message CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_0.dtd
@@ -1,0 +1,83 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Catalog 2.0//EN -->
+<!-- XML representation of Autoupdate Modules/Updates Catalog -->
+
+<!ELEMENT module_updates ((notification?, (module_group|module)*, license*)|error)>
+<!ATTLIST module_updates timestamp CDATA #REQUIRED>
+
+<!ELEMENT module_group ((module_group|module)*)>
+<!ATTLIST module_group name CDATA #REQUIRED>
+
+<!ELEMENT notification (#PCDATA)>
+<!ATTLIST notification url CDATA #IMPLIED>
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n) )>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #REQUIRED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #REQUIRED
+                 needsrestart CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>
+
+<!ELEMENT error (auth_error|other_error)>
+
+<!ELEMENT auth_error EMPTY>
+
+<!ELEMENT other_error EMPTY>
+<!ATTLIST other_error message CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_1.dtd
@@ -1,0 +1,86 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Catalog 2.1//EN -->
+<!-- XML representation of Autoupdate Modules/Updates Catalog -->
+
+<!ELEMENT module_updates ((notification?, (module_group|module)*, license*)|error)>
+<!ATTLIST module_updates timestamp CDATA #REQUIRED>
+
+<!ELEMENT module_group ((module_group|module)*)>
+<!ATTLIST module_group name CDATA #REQUIRED>
+
+<!ELEMENT notification (#PCDATA)>
+<!ATTLIST notification url CDATA #IMPLIED>
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n) )>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #REQUIRED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #REQUIRED
+                 needsrestart CDATA #IMPLIED
+                 release      CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED
+                   OpenIDE-Module-Deprecated CDATA #IMPLIED
+                   OpenIDE-Module-Deprecation-Message CDATA #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>
+
+<!ELEMENT error (auth_error|other_error)>
+
+<!ELEMENT auth_error EMPTY>
+
+<!ELEMENT other_error EMPTY>
+<!ATTLIST other_error message CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_2.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_2.dtd
@@ -1,0 +1,85 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Catalog 2.2//EN -->
+<!-- XML representation of Autoupdate Modules/Updates Catalog -->
+
+<!ELEMENT module_updates ((notification?, (module_group|module)*, license*)|error)>
+<!ATTLIST module_updates timestamp CDATA #REQUIRED>
+
+<!ELEMENT module_group ((module_group|module)*)>
+<!ATTLIST module_group name CDATA #REQUIRED>
+
+<!ELEMENT notification (#PCDATA)>
+<!ATTLIST notification url CDATA #IMPLIED>
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n) )>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #REQUIRED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #REQUIRED
+                 needsrestart CDATA #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>
+
+<!ELEMENT error (auth_error|other_error)>
+
+<!ELEMENT auth_error EMPTY>
+
+<!ELEMENT other_error EMPTY>
+<!ATTLIST other_error message CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_3.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_3.dtd
@@ -1,0 +1,86 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Catalog 2.3//EN -->
+<!-- XML representation of Autoupdate Modules/Updates Catalog -->
+
+<!ELEMENT module_updates ((notification?, (module_group|module)*, license*)|error)>
+<!ATTLIST module_updates timestamp CDATA #REQUIRED>
+
+<!ELEMENT module_group ((module_group|module)*)>
+<!ATTLIST module_group name CDATA #REQUIRED>
+
+<!ELEMENT notification (#PCDATA)>
+<!ATTLIST notification url CDATA #IMPLIED>
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n) )>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #REQUIRED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #REQUIRED
+                 needsrestart CDATA #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED
+                 global       CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>
+
+<!ELEMENT error (auth_error|other_error)>
+
+<!ELEMENT auth_error EMPTY>
+
+<!ELEMENT other_error EMPTY>
+<!ATTLIST other_error message CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_4.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_4.dtd
@@ -1,0 +1,87 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Catalog 2.4//EN -->
+<!-- XML representation of Autoupdate Modules/Updates Catalog -->
+
+<!ELEMENT module_updates ((notification?, (module_group|module)*, license*)|error)>
+<!ATTLIST module_updates timestamp CDATA #REQUIRED>
+
+<!ELEMENT module_group ((module_group|module)*)>
+<!ATTLIST module_group name CDATA #REQUIRED>
+
+<!ELEMENT notification (#PCDATA)>
+<!ATTLIST notification url CDATA #IMPLIED>
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n) )>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #REQUIRED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #REQUIRED
+                 needsrestart CDATA #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED
+                 global       CDATA #IMPLIED
+                 targetcluster CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>
+
+<!ELEMENT error (auth_error|other_error)>
+
+<!ELEMENT auth_error EMPTY>
+
+<!ELEMENT other_error EMPTY>
+<!ATTLIST other_error message CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_5.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_5.dtd
@@ -1,0 +1,86 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Catalog 2.5//EN -->
+<!-- XML representation of Autoupdate Modules/Updates Catalog -->
+
+<!ELEMENT module_updates ((notification?, (module_group|module)*, license*)|error)>
+<!ATTLIST module_updates timestamp CDATA #REQUIRED>
+
+<!ELEMENT module_group ((module_group|module)*)>
+<!ATTLIST module_group name CDATA #REQUIRED>
+
+<!ELEMENT notification (#PCDATA)>
+<!ATTLIST notification url CDATA #IMPLIED>
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n) )>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #REQUIRED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #REQUIRED
+                 needsrestart (true|false) #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED
+                 global       (true|false) #IMPLIED
+                 targetcluster CDATA #IMPLIED
+                 eager (true|false) #IMPLIED
+                 autoload (true|false) #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED
+                   OpenIDE-Module-Recommends CDATA #IMPLIED
+                   OpenIDE-Module-Needs CDATA #IMPLIED
+                   AutoUpdate-Show-In-Client (true|false) #IMPLIED
+                   AutoUpdate-Essential-Module (true|false) #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_6.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_6.dtd
@@ -1,0 +1,87 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Catalog 2.6//EN -->
+<!-- XML representation of Autoupdate Modules/Updates Catalog -->
+
+<!ELEMENT module_updates ((notification?, (module_group|module)*, license*)|error)>
+<!ATTLIST module_updates timestamp CDATA #REQUIRED>
+
+<!ELEMENT module_group ((module_group|module)*)>
+<!ATTLIST module_group name CDATA #REQUIRED>
+
+<!ELEMENT notification (#PCDATA)>
+<!ATTLIST notification url CDATA #IMPLIED>
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n) )>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #REQUIRED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #REQUIRED
+                 needsrestart (true|false) #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED
+                 global       (true|false) #IMPLIED
+                 targetcluster CDATA #IMPLIED
+                 eager (true|false) #IMPLIED
+                 autoload (true|false) #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED
+                   OpenIDE-Module-Recommends CDATA #IMPLIED
+                   OpenIDE-Module-Needs CDATA #IMPLIED
+                   AutoUpdate-Show-In-Client (true|false) #IMPLIED
+                   AutoUpdate-Essential-Module (true|false) #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED
+                  url  CDATA #IMPLIED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_7.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-catalog-2_7.dtd
@@ -1,0 +1,91 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Catalog 2.7//EN -->
+<!-- XML representation of Autoupdate Modules/Updates Catalog -->
+
+<!ELEMENT module_updates ((notification?, content_description?, (module_group|module)*, license*)|error)>
+<!ATTLIST module_updates timestamp CDATA #REQUIRED>
+
+<!ELEMENT module_group ((module_group|module)*)>
+<!ATTLIST module_group name CDATA #REQUIRED>
+
+<!ELEMENT notification (#PCDATA)>
+<!ATTLIST notification url CDATA #IMPLIED>
+
+<!ELEMENT content_description (#PCDATA)>
+<!ATTLIST content_description url CDATA #IMPLIED>
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n) )>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #REQUIRED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #REQUIRED
+                 needsrestart (true|false) #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED
+                 global       (true|false) #IMPLIED
+                 targetcluster CDATA #IMPLIED
+                 preferredupdate (true|false) #IMPLIED
+                 eager (true|false) #IMPLIED
+                 autoload (true|false) #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED
+                   OpenIDE-Module-Recommends CDATA #IMPLIED
+                   OpenIDE-Module-Needs CDATA #IMPLIED
+                   AutoUpdate-Show-In-Client (true|false) #IMPLIED
+                   AutoUpdate-Essential-Module (true|false) #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED
+                  url  CDATA #IMPLIED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-info-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-info-1_0.dtd
@@ -1,0 +1,60 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Module Info 1.0//EN -->
+<!-- XML representation of Autoupdate Module Info file -->
+<!-- (Info.xml is included in NBM archive) -->
+
+<!ELEMENT module (description?, module_notification?, external_package*, manifest, license?)>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #IMPLIED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #IMPLIED
+                 needsrestart CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-info-2_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-info-2_0.dtd
@@ -1,0 +1,68 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Module Info 2.0//EN -->
+<!-- XML representation of Autoupdate Module Info file -->
+<!-- (Info.xml is included in NBM archive) -->
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n), license?)>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #IMPLIED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #IMPLIED
+                 needsrestart CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-info-2_2.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-info-2_2.dtd
@@ -1,0 +1,70 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Module Info 2.2//EN -->
+<!-- XML representation of Autoupdate Module Info file -->
+<!-- (Info.xml is included in NBM archive) -->
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n), license?)>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #IMPLIED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #IMPLIED
+                 needsrestart CDATA #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-info-2_3.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-info-2_3.dtd
@@ -1,0 +1,71 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Module Info 2.3//EN -->
+<!-- XML representation of Autoupdate Module Info file -->
+<!-- (Info.xml is included in NBM archive) -->
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n), license?)>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #IMPLIED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #IMPLIED
+                 needsrestart CDATA #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED
+                 global       CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-info-2_4.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-info-2_4.dtd
@@ -1,0 +1,72 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Module Info 2.4//EN -->
+<!-- XML representation of Autoupdate Module Info file -->
+<!-- (Info.xml is included in NBM archive) -->
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n), license?)>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #IMPLIED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #IMPLIED
+                 needsrestart CDATA #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED
+                 global       CDATA #IMPLIED
+                 targetcluster CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-info-2_5.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-info-2_5.dtd
@@ -1,0 +1,76 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Module Info 2.5//EN -->
+<!-- XML representation of Autoupdate Module Info file -->
+<!-- (Info.xml is included in NBM archive) -->
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n), license?)>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #REQUIRED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #REQUIRED
+                 needsrestart (true|false) #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED
+                 global       (true|false) #IMPLIED
+                 targetcluster CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED
+                   OpenIDE-Module-Recommends CDATA #IMPLIED
+                   OpenIDE-Module-Needs CDATA #IMPLIED
+                   AutoUpdate-Show-In-Client (true|false) #IMPLIED
+                   AutoUpdate-Essential-Module (true|false) #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/autoupdate-info-2_7.dtd
+++ b/netbeans.apache.org/src/content/dtds/autoupdate-info-2_7.dtd
@@ -1,0 +1,77 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Autoupdate Module Info 2.7//EN -->
+<!-- XML representation of Autoupdate Module Info file -->
+<!-- (Info.xml is included in NBM archive) -->
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n), license?)>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #REQUIRED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #REQUIRED
+                 needsrestart (true|false) #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED
+                 global       (true|false) #IMPLIED
+                 preferredupdate (true|false) #IMPLIED
+                 targetcluster CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED
+                   OpenIDE-Module-Recommends CDATA #IMPLIED
+                   OpenIDE-Module-Needs CDATA #IMPLIED
+                   AutoUpdate-Show-In-Client (true|false) #IMPLIED
+                   AutoUpdate-Essential-Module (true|false) #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/catalog
+++ b/netbeans.apache.org/src/content/dtds/catalog
@@ -1,0 +1,83 @@
+--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+--
+
+-- Catalog of public IDs to DTD filenames; XML tools can understand it --
+
+public "-//NetBeans IDE//DTD toolbar//EN" toolbar.dtd
+public "-//NetBeans//DTD Autoupdate Catalog 1.0//EN" autoupdate-catalog-1_0.dtd
+public "-//NetBeans//DTD Autoupdate Catalog 2.0//EN" autoupdate-catalog-2_0.dtd
+public "-//NetBeans//DTD Autoupdate Catalog 2.2//EN" autoupdate-catalog-2_2.dtd
+public "-//NetBeans//DTD Autoupdate Catalog 2.3//EN" autoupdate-catalog-2_3.dtd
+public "-//NetBeans//DTD Autoupdate Catalog 2.4//EN" autoupdate-catalog-2_4.dtd
+public "-//NetBeans//DTD Autoupdate Catalog 2.5//EN" autoupdate-catalog-2_5.dtd
+public "-//NetBeans//DTD Autoupdate Catalog 2.6//EN" autoupdate-catalog-2_6.dtd
+public "-//NetBeans//DTD Autoupdate Catalog 2.7//EN" autoupdate-catalog-2_7.dtd
+public "-//NetBeans//DTD Autoupdate Catalog 3.0//EN" autoupdate-catalog-3_0.dtd
+public "-//NetBeans//DTD Autoupdate Module Info 1.0//EN" autoupdate-info-1_0.dtd
+public "-//NetBeans//DTD Autoupdate Module Info 2.0//EN" autoupdate-info-2_0.dtd
+public "-//NetBeans//DTD Autoupdate Module Info 2.2//EN" autoupdate-info-2_2.dtd
+public "-//NetBeans//DTD Autoupdate Module Info 2.3//EN" autoupdate-info-2_3.dtd
+public "-//NetBeans//DTD Autoupdate Module Info 2.4//EN" autoupdate-info-2_4.dtd
+public "-//NetBeans//DTD Autoupdate Module Info 2.5//EN" autoupdate-info-2_5.dtd
+public "-//NetBeans//DTD Autoupdate Module Info 2.7//EN" autoupdate-info-2_7.dtd
+public "-//NetBeans//DTD Autoupdate Module Info 3.0//EN" autoupdate-info-3_0.dtd
+public "-//NetBeans//DTD DefaultAttributes 1.0//EN" attributes-1_0.dtd
+public "-//NetBeans//DTD Editor Abbreviations settings 1.0//EN" EditorAbbreviations-1_0.dtd
+public "-//NetBeans//DTD Editor Fonts and Colors settings 1.0//EN" EditorFontsColors-1_0.dtd
+public "-//NetBeans//DTD Editor KeyBindings settings 1.0//EN" EditorKeyBindings-1_0.dtd
+public "-//NetBeans//DTD Editor Macros settings 1.0//EN" EditorMacros-1_0.dtd
+public "-//NetBeans//DTD Editor Properties settings 1.0//EN" EditorProperties-1_0.dtd
+public "-//NetBeans//DTD Filesystem 1.0//EN" filesystem-1_0.dtd
+public "-//NetBeans//DTD Filesystem 1.1//EN" filesystem-1_1.dtd
+public "-//NetBeans//DTD Group Properties 2.0//EN" group-properties2_0.dtd
+public "-//NetBeans//DTD Help Context 1.0//EN" helpcontext-1_0.dtd
+public "-//NetBeans//DTD Java PlatformDefinition 1.0//EN" java-platformdefinition-1_0.dtd
+public "-//NetBeans//DTD JavaHelp Help Set Reference 1.0//EN" helpsetref-1_0.dtd
+public "-//NetBeans//DTD MIME Resolver 1.0//EN" mime-resolver-1_0.dtd
+public "-//NetBeans//DTD MIME Resolver XML Rules 1.0//EN" mime-resolver-xml-component-1_0.dtd
+public "-//NetBeans//DTD Mode Properties 1.0//EN" mode-properties1_0.dtd
+public "-//NetBeans//DTD Mode Properties 1.1//EN" mode-properties1_1.dtd
+public "-//NetBeans//DTD Mode Properties 1.2//EN" mode-properties1_2.dtd
+public "-//NetBeans//DTD Mode Properties 2.0//EN" mode-properties2_0.dtd
+public "-//NetBeans//DTD Mode Properties 2.0//EN" mode-properties2_1.dtd
+public "-//NetBeans//DTD Module Automatic Dependencies 1.0//EN" module-auto-deps-1_0.dtd
+public "-//NetBeans//DTD Module Status 1.0//EN" module-status-1_0.dtd
+public "-//NetBeans//DTD PDF Document Menu Link 1.0//EN" pdf_link-1_0.dtd
+public "-//NetBeans//DTD Session settings 1.0//EN" sessionsettings-1_0.dtd
+public "-//NetBeans//DTD Simple Instance 1.0//EN" instance-1_0.dtd
+public "-//NetBeans//DTD Top Component in Group Properties 2.0//EN" tc-group2_0.dtd
+public "-//NetBeans//DTD Top Component in Mode Properties 1.0//EN" tc-ref1_0.dtd
+public "-//NetBeans//DTD Top Component in Mode Properties 2.0//EN" tc-ref2_0.dtd
+public "-//NetBeans//DTD Top Component in Mode Properties 2.0//EN" tc-ref2_1.dtd
+public "-//NetBeans//DTD VCS Advanced FSSettings 1.0//EN" vcs-advanced-fssettings-1_0.dtd
+public "-//NetBeans//DTD VCS Configuration 1.0//EN" vcs-configuration-1_0.dtd
+public "-//NetBeans//DTD Window Manager Properties 1.0//EN" windowmanager-properties1_0.dtd
+public "-//NetBeans//DTD Window Manager Properties 1.1//EN" windowmanager-properties1_1.dtd
+public "-//NetBeans//DTD Window Manager Properties 2.0//EN" windowmanager-properties2_0.dtd
+public "-//NetBeans//DTD Workspace Properties 1.0//EN" workspace-properties1_0.dtd
+public "-//NetBeans//DTD Workspace Properties 1.1//EN" workspace-properties1_1.dtd
+public "-//NetBeans//DTD XTest Master Config 1.0//EN" xtest-master-config-1_0.dtd
+public "-//NetBeans//DTD XTest cfg 1.0//EN" xtest-cfg-1_0.dtd
+public "-//NetBeans//DTD annotation type 1.0//EN" annotation-type-1_0.dtd
+public "-//NetBeans//DTD annotation type 1.1//EN" annotation-type-1_1.dtd
+public "-//NetBeans//Entity Mapping Registration 1.0//EN" EntityCatalog-1_0.dtd
+
+-- Externally cached DTDs: --
+
+public "-//W3C//DTD XHTML 1.0 Strict//EN" ../../../libs/external/dtds/xhtml1-20020801/DTD/xhtml1-strict.dtd

--- a/netbeans.apache.org/src/content/dtds/catalog.xml
+++ b/netbeans.apache.org/src/content/dtds/catalog.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE catalog PUBLIC "-//OASIS//DTD XML Catalogs V1.0//EN" "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="public">
+    <uri name="https://netbeans.org/ns/ant-project-references/1" uri="../ns/ant-project-references/1.xsd"/>
+    <uri name="https://netbeans.org/ns/ant-project-references/2" uri="../ns/ant-project-references/2.xsd"/>
+    <uri name="https://netbeans.org/ns/freeform-project-java/1" uri="../ns/freeform-project-java/1.xsd"/>
+    <uri name="https://netbeans.org/ns/freeform-project-java/2" uri="../ns/freeform-project-java/2.xsd"/>
+    <uri name="https://netbeans.org/ns/freeform-project-web/1" uri="../ns/freeform-project-web/1.xsd"/>
+    <uri name="https://netbeans.org/ns/freeform-project/1" uri="../ns/freeform-project/1.xsd"/>
+    <uri name="https://netbeans.org/ns/freeform-project/2" uri="../ns/freeform-project/2.xsd"/>
+    <uri name="https://netbeans.org/ns/j2se-project-private/1" uri="../ns/j2se-project-private/1.xsd"/>
+    <uri name="https://netbeans.org/ns/j2se-project/1" uri="../ns/j2se-project/1.xsd"/>
+    <uri name="https://netbeans.org/ns/nb-module-project-private/1" uri="../ns/nb-module-project-private/1.xsd"/>
+    <uri name="https://netbeans.org/ns/nb-module-project/1" uri="../ns/nb-module-project/1.xsd"/>
+    <uri name="https://netbeans.org/ns/nb-module-project/2" uri="../ns/nb-module-project/2.xsd"/>
+    <uri name="https://netbeans.org/ns/nb-module-project/3" uri="../ns/nb-module-project/3.xsd"/>
+    <uri name="https://netbeans.org/ns/nb-module-suite-project-private/1" uri="../ns/nb-module-suite-project-private/1.xsd"/>
+    <uri name="https://netbeans.org/ns/nb-module-suite-project/1" uri="../ns/nb-module-suite-project/1.xsd"/>
+    <uri name="https://netbeans.org/ns/project-private/1" uri="../ns/project-private/1.xsd"/>
+    <uri name="https://netbeans.org/ns/project/1" uri="../ns/project/1.xsd"/>
+    <uri name="https://netbeans.org/ns/projectui-open-files/1" uri="../ns/projectui-open-files/1.xsd"/>
+    <uri name="https://netbeans.org/ns/web-project-private/1" uri="../ns/web-project-private/1.xsd"/>
+    <uri name="https://netbeans.org/ns/web-project/1" uri="../ns/web-project/1.xsd"/>
+    <!-- XXX missing: everything Java EE -->
+</catalog>

--- a/netbeans.apache.org/src/content/dtds/connection-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/connection-1_0.dtd
@@ -1,0 +1,52 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--- The root connection element. -->
+<!ELEMENT connection (driver-class,driver-name,database-url,schema,user)>
+
+<!--- The driver class. -->
+<!ELEMENT driver-class EMPTY>
+<!ATTLIST driver-class 
+    value CDATA #REQUIRED
+>
+
+<!--- The driver name. -->
+<!ELEMENT driver-name EMPTY>
+<!ATTLIST driver-name 
+    value CDATA #REQUIRED
+>
+
+<!--- The database URL. -->
+<!ELEMENT database-url EMPTY>
+<!ATTLIST database-url 
+    value CDATA #REQUIRED
+>
+
+<!--- The schema to which to connect by default. -->
+<!ELEMENT schema EMPTY>
+<!ATTLIST schema 
+    value CDATA #REQUIRED
+>
+
+<!--- The database user to connect as. -->
+<!ELEMENT user EMPTY>
+<!ATTLIST user 
+    value CDATA #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/connection-1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/connection-1_1.dtd
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--- The root connection element. -->
+<!ELEMENT connection (driver-class,driver-name,database-url,schema,user,password)>
+
+<!--- The driver class. -->
+<!ELEMENT driver-class EMPTY>
+<!ATTLIST driver-class
+    value CDATA #REQUIRED
+>
+
+<!--- The driver name. -->
+<!ELEMENT driver-name EMPTY>
+<!ATTLIST driver-name
+    value CDATA #REQUIRED
+>
+
+<!--- The database URL. -->
+<!ELEMENT database-url EMPTY>
+<!ATTLIST database-url
+    value CDATA #REQUIRED
+>
+
+<!--- The schema to which to connect by default. -->
+<!ELEMENT schema EMPTY>
+<!ATTLIST schema
+    value CDATA #REQUIRED
+>
+
+<!--- The database user to connect as. -->
+<!ELEMENT user EMPTY>
+<!ATTLIST user 
+    value CDATA #REQUIRED
+>
+<!--- The database password (hashed). -->
+<!ELEMENT password EMPTY>
+<!ATTLIST password 
+    value CDATA #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/editor-palette-item-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/editor-palette-item-1_0.dtd
@@ -1,0 +1,96 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--- Editor Palette Item -->
+
+<!--
+<editor_palette_item version="1.0">
+-->
+<!ELEMENT editor_palette_item ((class|body),icon16,icon32,description)>
+<!ATTLIST editor_palette_item
+    version CDATA #REQUIRED
+>
+
+<!--
+Name of class implementing org.openide.text.ActiveEditorDrop interface; e.g.
+<class name="org.netbeans.modules.html.palette.items.TABLE" />
+-->
+<!ELEMENT class EMPTY>
+<!ATTLIST class 
+    name CDATA #REQUIRED
+>
+
+<!--
+Item body if no custom implementation is provided, e.g.
+<body>
+    <![CDATA[
+        <table border="1">
+            <thead>
+                <tr>
+                    <th></th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td></td>
+                    <td></td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td></td>
+                </tr>
+            </tbody>
+        </table>
+    ]]>
+</body>
+-->
+<!ELEMENT body (#PCDATA)>
+
+<!--
+Resource path of the small icon 16x16 (no initial slash), e.g.
+<icon16 urlvalue="org/netbeans/modules/html/palette/items/resources/TABLE16.gif" />
+-->
+<!ELEMENT icon16 EMPTY>
+<!ATTLIST icon16 
+    urlvalue CDATA #REQUIRED
+>
+
+<!--
+Resource path of the big icon 32x32 (no initial slash), e.g.
+<icon32 urlvalue="org/netbeans/modules/html/palette/items/resources/TABLE32.gif" />
+-->
+<!ELEMENT icon32 EMPTY>
+<!ATTLIST icon32 
+    urlvalue CDATA #REQUIRED
+>
+
+<!--
+Bundle name with display name key and tooltip key, e.g.
+<description localizing-bundle="org.netbeans.modules.html.palette.items.resources.Bundle"
+           display-name-key="NAME_html-TABLE"
+           tooltip-key="HINT_html-TABLE" />
+-->
+<!ELEMENT description EMPTY>
+<!ATTLIST description 
+    localizing-bundle CDATA #REQUIRED
+    display-name-key CDATA #REQUIRED
+    tooltip-key CDATA #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/editor-palette-item-1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/editor-palette-item-1_1.dtd
@@ -1,0 +1,109 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--- Editor Palette Item -->
+
+<!--
+<editor_palette_item version="1.1">
+-->
+<!ELEMENT editor_palette_item ((class|body),icon16,icon32,(description|inline-description))>
+<!ATTLIST editor_palette_item
+    version CDATA #REQUIRED
+>
+
+<!--
+Name of class implementing org.openide.text.ActiveEditorDrop interface; e.g.
+<class name="org.netbeans.modules.html.palette.items.TABLE" />
+-->
+<!ELEMENT class EMPTY>
+<!ATTLIST class
+    name CDATA #REQUIRED
+>
+
+<!--
+Item body if no custom implementation is provided, e.g.
+<body>
+    <![CDATA[
+        <table border="1">
+            <thead>
+                <tr>
+                    <th></th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td></td>
+                    <td></td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td></td>
+                </tr>
+            </tbody>
+        </table>
+    ]]>
+</body>
+-->
+<!ELEMENT body (#PCDATA)>
+
+<!--
+Resource path of the small icon 16x16 (no initial slash), e.g.
+<icon16 urlvalue="org/netbeans/modules/html/palette/items/resources/TABLE16.gif" />
+-->
+<!ELEMENT icon16 EMPTY>
+<!ATTLIST icon16 
+    urlvalue CDATA #REQUIRED
+>
+
+<!--
+Resource path of the big icon 32x32 (no initial slash), e.g.
+<icon32 urlvalue="org/netbeans/modules/html/palette/items/resources/TABLE32.gif" />
+-->
+<!ELEMENT icon32 EMPTY>
+<!ATTLIST icon32 
+    urlvalue CDATA #REQUIRED
+>
+
+<!--
+Bundle name with display name key and tooltip key, e.g.
+<description localizing-bundle="org.netbeans.modules.html.palette.items.resources.Bundle"
+           display-name-key="NAME_html-TABLE"
+           tooltip-key="HINT_html-TABLE" />
+-->
+<!ELEMENT description EMPTY>
+<!ATTLIST description 
+    localizing-bundle CDATA #REQUIRED
+    display-name-key CDATA #REQUIRED
+    tooltip-key CDATA #REQUIRED
+>
+
+<!--
+Display name key and tooltip key, e.g.
+<inline-description>
+           <display-name>Table</display-name>
+           <tooltip> <![CDATA[ <table border="1"> <tr> <td></td> <td></td> </tr> <tr> <td></td> <td></td> </tr> </table> ]]> </tooltip>
+</inline-description>
+-->
+<!ELEMENT inline-description (display-name, tooltip)>
+
+<!ELEMENT display-name (#PCDATA)>
+
+<!ELEMENT tooltip (#PCDATA)>

--- a/netbeans.apache.org/src/content/dtds/filesystem-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/filesystem-1_0.dtd
@@ -1,0 +1,48 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Filesystem 1.0//EN -->
+<!-- XML representation of a fixed filesystem -->
+<!-- as for example a module layer. -->
+<!-- See: org.openide.filesystems.XMLFileSystem -->
+<!ELEMENT filesystem   (file|folder)*      >
+<!ELEMENT folder       (folder|file|attr)*   >
+<!ELEMENT file         (#PCDATA|attr)*>
+<!ELEMENT attr    EMPTY               >
+<!ATTLIST filesystem                       >
+<!ATTLIST folder
+          name         CDATA #REQUIRED     >
+<!ATTLIST file
+          name         CDATA #REQUIRED
+          url          CDATA #IMPLIED      >
+<!ATTLIST attr
+          name         CDATA #REQUIRED
+          bytevalue    CDATA #IMPLIED
+          shortvalue   CDATA #IMPLIED
+          intvalue     CDATA #IMPLIED
+          longvalue    CDATA #IMPLIED
+          floatvalue   CDATA #IMPLIED
+          doublevalue  CDATA #IMPLIED
+          boolvalue    CDATA #IMPLIED
+          charvalue    CDATA #IMPLIED
+          stringvalue  CDATA #IMPLIED
+          urlvalue     CDATA #IMPLIED
+          methodvalue  CDATA #IMPLIED
+          serialvalue  CDATA #IMPLIED      >

--- a/netbeans.apache.org/src/content/dtds/filesystem-1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/filesystem-1_1.dtd
@@ -1,0 +1,49 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Filesystem 1.1//EN -->
+<!-- XML representation of a fixed filesystem -->
+<!-- as for example a module layer. -->
+<!-- See: org.openide.filesystems.XMLFileSystem -->
+<!ELEMENT filesystem   (file|folder|attr)*      >
+<!ELEMENT folder       (folder|file|attr)*   >
+<!ELEMENT file         (#PCDATA|attr)*>
+<!ELEMENT attr    EMPTY               >
+<!ATTLIST filesystem                       >
+<!ATTLIST folder
+          name         CDATA #REQUIRED     >
+<!ATTLIST file
+          name         CDATA #REQUIRED
+          url          CDATA #IMPLIED      >
+<!ATTLIST attr
+          name         CDATA #REQUIRED
+          bytevalue    CDATA #IMPLIED
+          shortvalue   CDATA #IMPLIED
+          intvalue     CDATA #IMPLIED
+          longvalue    CDATA #IMPLIED
+          floatvalue   CDATA #IMPLIED
+          doublevalue  CDATA #IMPLIED
+          boolvalue    CDATA #IMPLIED
+          charvalue    CDATA #IMPLIED
+          stringvalue  CDATA #IMPLIED
+          urlvalue     CDATA #IMPLIED
+          methodvalue  CDATA #IMPLIED
+          newvalue     CDATA #IMPLIED
+          serialvalue  CDATA #IMPLIED      >

--- a/netbeans.apache.org/src/content/dtds/filesystem-1_2.dtd
+++ b/netbeans.apache.org/src/content/dtds/filesystem-1_2.dtd
@@ -1,0 +1,50 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Filesystem 1.2//EN -->
+<!-- XML representation of a fixed filesystem -->
+<!-- as for example a module layer. -->
+<!-- See: org.openide.filesystems.XMLFileSystem -->
+<!ELEMENT filesystem   (file|folder|attr)*      >
+<!ELEMENT folder       (folder|file|attr)*   >
+<!ELEMENT file         (#PCDATA|attr)*>
+<!ELEMENT attr    EMPTY               >
+<!ATTLIST filesystem                       >
+<!ATTLIST folder
+          name         CDATA #REQUIRED     >
+<!ATTLIST file
+          name         CDATA #REQUIRED
+          url          CDATA #IMPLIED      >
+<!ATTLIST attr
+          name         CDATA #REQUIRED
+          bytevalue    CDATA #IMPLIED
+          shortvalue   CDATA #IMPLIED
+          intvalue     CDATA #IMPLIED
+          longvalue    CDATA #IMPLIED
+          floatvalue   CDATA #IMPLIED
+          doublevalue  CDATA #IMPLIED
+          boolvalue    CDATA #IMPLIED
+          charvalue    CDATA #IMPLIED
+          stringvalue  CDATA #IMPLIED
+          urlvalue     CDATA #IMPLIED
+          methodvalue  CDATA #IMPLIED
+          newvalue     CDATA #IMPLIED
+          serialvalue  CDATA #IMPLIED
+          bundlevalue  CDATA #IMPLIED      >

--- a/netbeans.apache.org/src/content/dtds/group-properties2_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/group-properties2_0.dtd
@@ -1,0 +1,69 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Group Properties 2.0//EN
+-->
+
+<!-- The root element for group properties. Consists of subelements
+     for specific properties.
+     Attribute "version" is versioning attribute which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT group (module?, name, state) >
+<!ATTLIST group
+    version CDATA #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of top component reference defined by module if module
+    is disabled.
+    If you want your module's group to be removed
+    automatically when your module is disabled, fill this element.
+    When this element is missing, no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!-- Element name
+    "unique" represents unique name of group
+-->
+<!ELEMENT name      EMPTY >
+<!ATTLIST name
+    unique   CDATA        #REQUIRED
+>
+
+<!-- Element state describes state of group.
+    "opened" is flag describing if group is opened or not. "true" if group is opened,
+    "false" if group is closed.
+-->
+<!ELEMENT state      EMPTY >
+<!ATTLIST state
+    opened (true | false) #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/helpcontext-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/helpcontext-1_0.dtd
@@ -1,0 +1,34 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Help Context 1.0//EN
+https://netbeans.org/dtds/helpcontext-1_0.dtd
+A JavaHelp help ID which could be used in a menu, etc.
+May optionally display whole master help set, otherwise
+just shows the help set in which the ID is defined.
+Example usage:
+<helpctx id="org.netbeans.modules.foo.some-topic"/>
+-->
+<!ELEMENT helpctx EMPTY>
+<!ATTLIST helpctx
+    id CDATA #REQUIRED
+    showmaster (true | false) "false"
+>

--- a/netbeans.apache.org/src/content/dtds/helpsetref-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/helpsetref-1_0.dtd
@@ -1,0 +1,32 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD JavaHelp Help Set Reference 1.0//EN
+https://netbeans.org/dtds/helpsetref-1_0.dtd
+Reference to a JavaHelp .hs file, optionally merged into master set.
+Example usage:
+<helpsetref url="nbdocs:/org/netbeans/modules/foo/help/HelpSet.hs"/>
+-->
+<!ELEMENT helpsetref EMPTY>
+<!ATTLIST helpsetref
+    url CDATA #REQUIRED
+    merge (true | false) "true"
+>

--- a/netbeans.apache.org/src/content/dtds/instance-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/instance-1_0.dtd
@@ -1,0 +1,30 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- -//NetBeans//DTD Simple Instance 1.0//EN -->
+<!-- Represents a simple instance of a class; -->
+<!-- either a default instance or a serialized bean. -->
+<!-- Can also be a holder for the class rather than an instance thereof. -->
+<!ELEMENT instance       EMPTY>
+<!ATTLIST instance
+          class          CDATA        #REQUIRED
+          serialdata     CDATA        #IMPLIED
+          uninstantiated (true|false) "false"
+>

--- a/netbeans.apache.org/src/content/dtds/j2me-platformdefinition-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/j2me-platformdefinition-1_0.dtd
@@ -1,0 +1,166 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+    TODO define vocabulary identification
+    PUBLIC ID: -//vendor//vocabulary//EN
+    SYSTEM ID: http://server/path/platform.dtd
+
+--><!--
+    An example how to use this DTD from your XML document:
+
+    <?xml version='1.0'?>
+
+    <!DOCTYPE platform PUBLIC '-//NetBeans//DTD J2ME PlatformDefinition 1.0//EN' 'https://netbeans.org/dtds/j2me-platformdefinition-1_0.dtd'>
+
+    <platform>
+    ...
+    </platform>
+-->
+
+<!--- 
+name - identification of the platform. The platform is always referenced by the name so the name must be unique among all installed platforms within the IDE
+home - base folder of the platform installation
+type - platform type.  Valid values are currently: UEI-1.0, UEI-1.0.1, and CUSTOM
+displayname - displayed name of the platform. When not specified name is used instead
+srcpath - optional list of folders, jars and zip files with platform sources
+docpath - optional list of folders, jars, zip files and URLs containing platform JavaDoc
+- all the paths are comma separated lists
+- ${platform.home} can be used to reference the platform home directory
+
+preverifycmd - command line used for preverification, this command line is used only when the platform type is set to CUSTOM
+runcmd - command line used for emulator execution, this command line is used only when the platform type is set to CUSTOM
+debugcmd - command line used for debugging, this command line is used only when the platform type is set to CUSTOM
+- samples of UEI-1.0 command lines:
+    preverifycmd: &quot;{platformhome}{/}bin{/}preverify&quot; {classpath|-classpath &quot;{classpath}&quot;} -d &quot;{destdir}&quot; &quot;{srcdir}&quot;
+    runcmd: &quot;{platformhome}{/}bin{/}emulator&quot; {device|-Xdevice:&quot;{device}&quot;} {jadfile|-Xdescriptor:&quot;{jadfile}&quot;} {securitydomain|-Xdomain:{securitydomain}}
+    debugcmd: &quot;{platformhome}{/}bin{/}emulator&quot; {device|-Xdevice:&quot;{device}&quot;} {jadfile|-Xdescriptor:&quot;{jadfile}&quot;} {securitydomain|-Xdomain:{securitydomain}} {debug|-Xdebug -Xrunjdwp:transport={debugtransport},server={debugserver},suspend={debugsuspend},address={debugaddress}}
+- format of the command lines (EMapFormat) is following:
+    {argument|command line part} is a condition, if argument is set to some value the command line part will be added to the command line
+    {argument} is a simple replacement, so for example {jadfile} will be replaced by the real path to the jad file
+    combination of condition and simple replacement is allowed. For example: {jadfile|-Xdescriptor:&quot;{jadfile}&quot;} means that if the jadfile argument contains /myfolder/my.jad then -Xdescriptor:"/myfolder/my.jad" will be added to the command line
+- known preverifycmd arguments:
+    platformhome - always set - value of PlatformHome attribute
+    srcdir - value of SrcDir attribute
+    destdir - value of DestDir attribute
+    classpath - classpath string composed from ClassPath, ClassPathRef, nested ClassPath
+    / - value of File.separator
+- known runcmd and debugcmd arguments:
+    platformhome - always set - value of PlatformHome attribute
+    device - value of Device attribute
+    classpath - classpath string composed from ClassPath, ClassPathRef, nested ClassPath
+    jadfile - value of JadFile attribute
+    jadurl - value of JadUrl attribute
+    securitydomain - value of SecurityDomain attribute
+    debug - value of Debug attribute, this is just a switch that indicates debugging
+    debugaddress - value of DebugAddress attribute
+    debugtransport - value of DebugTransport attribute
+    debugserver - value of DebugServer attribute. Default: true.
+    debugsuspend - value of DebugSuspend attribute. Default: true.
+    / - value of File.separator
+
+ -->
+<!ELEMENT platform (device)+>
+<!ATTLIST platform
+    name CDATA #REQUIRED
+    home CDATA #REQUIRED
+    type CDATA #REQUIRED
+    displayname CDATA #IMPLIED
+    srcpath CDATA #IMPLIED
+    docpath CDATA #IMPLIED
+    preverifycmd CDATA #IMPLIED
+    runcmd CDATA #IMPLIED
+    debugcmd CDATA #IMPLIED
+  >
+
+<!--- 
+name - device name is the unique identification of the device within the platform
+description - optional description of the device
+securitydomains - list of allowed security domains for this device
+ -->
+<!ELEMENT device (configuration+,profile+,optional*,screen?)>
+<!ATTLIST device
+    name CDATA #REQUIRED
+    description CDATA #IMPLIED
+    securitydomains CDATA #IMPLIED
+  >
+
+<!ELEMENT screen EMPTY>
+<!ATTLIST screen
+    width CDATA #IMPLIED
+    height CDATA #IMPLIED
+    bitDepth CDATA #IMPLIED
+    isColor (true|false) "true"
+    isTouch (true|false) "false"
+>
+
+<!---
+name - configuration name will usually be CLDC
+version - version number in text format. For example: 1.0
+displayname - expanded name of the configuration. For example: Connected Limited Device Configuration
+classpath - comma separated list of folders, jars and zip files that belong to the configuration
+          - don't worry about duplicate usage of the classpath elements between configuration and profile (when they are packed together) or between different devices
+default - boolean specifying if this configuration is default. Valid values are true or false. Exactly one configuration must be set as default.
+ -->
+<!ELEMENT configuration EMPTY>
+<!ATTLIST configuration
+    name CDATA #REQUIRED
+    version CDATA #REQUIRED
+    displayname CDATA #IMPLIED
+    classpath CDATA #IMPLIED
+    default CDATA #IMPLIED
+  >
+
+<!--- 
+name - profile name will usually be MIDP
+version - version number in text format. For example 1.0
+dependencies - list of configuration dependencies
+displayname - expanded name of the profile. For example: Mobile Information Device Profile
+classpath - comma separated list of folders, jars and zip files that belong to the profile
+          - don't worry about duplicate usage of the classpath elements between configuration and profile (when they are packed together) or between different devices
+default - boolean specifying if this profile is default. Valid values are true or false. Exactly one profile must be set as default.        
+ -->
+<!ELEMENT profile EMPTY>
+<!ATTLIST profile
+    name CDATA #REQUIRED
+    version CDATA #REQUIRED
+    dependencies CDATA #IMPLIED
+    displayname CDATA #IMPLIED
+    classpath CDATA #IMPLIED
+    default CDATA #IMPLIED
+  >
+
+<!--- name - optional API name, for example MMAPI
+version - version number in text format, for example 1.0
+dependencies - list of dependencies on configurations, profiles, or other optional APIs of the same device
+displayname - expanded name of the optional API. For example: Mobile Media API
+classpath - comma separated list of folders, jars and zip files that belong to the optional API
+          - class path elements of the optional APIs should not be listed on classpath of the configuration, profile or other optional API of the same device
+default - boolean identification specifying if this optional API is enabled by default. Valid values are true or false. Any number of optional APIs may be enabled by default          
+ -->
+<!ELEMENT optional EMPTY>
+<!ATTLIST optional
+    name CDATA #REQUIRED
+    version CDATA #REQUIRED
+    dependencies CDATA #IMPLIED
+    displayname CDATA #IMPLIED
+    classpath CDATA #IMPLIED
+    default CDATA #IMPLIED
+  >

--- a/netbeans.apache.org/src/content/dtds/java-platformdefinition-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/java-platformdefinition-1_0.dtd
@@ -1,0 +1,69 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- "-//NetBeans//DTD Java PlatformDefinition 1.0//EN" "https://netbeans.org/dtds/java-platformdefinition-1_0.dtd" -->
+
+<!--
+    DTD to describe a standard JDK/JRE installation
+-->
+
+<!-- 
+attributes: 
+    name = displayed name of the platform, must be present unless
+     the platform is default.
+    default = yes|<missing>
+-->    
+<!ELEMENT platform (jdkhome?,properties?,sysproperties?,sources?,javadoc?)>
+<!ATTLIST platform 
+    name CDATA #IMPLIED
+    default CDATA #IMPLIED
+>
+
+<!--
+Properties element lists various properties associated with the Platform
+by extension modules.
+-->
+<!ELEMENT properties (property)*>
+
+<!--
+Sysproperties hold a list of system properties as reported by the JDK
+-->
+<!ELEMENT sysproperties (property)*>
+
+<!--Holds the roots where the jdk is installed -->
+<!ELEMENT jdkhome (resource)*>
+
+<!--Holds the source roots of the jdk-->
+<!ELEMENT sources (resource)*>
+
+<!--Holds the roots of the jdk's javadoc-->
+<!ELEMENT javadoc (resource)*>
+
+<!--Represents a root of a path, holds a stringified URL-->
+<!ELEMENT resource (#PCDATA)>
+
+<!--
+Definition of one property: it has a name and some optional string data
+-->
+<!ELEMENT property EMPTY>
+<!ATTLIST property
+    name CDATA #REQUIRED
+    value CDATA #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/jdbc-driver-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/jdbc-driver-1_0.dtd
@@ -1,0 +1,43 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--- Description of the registered driver. -->
+<!ELEMENT driver (name|class|urls)*>
+
+<!--- Programmatic name of the driver. -->
+<!ELEMENT name EMPTY>
+<!ATTLIST name
+    value CDATA #REQUIRED
+  >
+
+<!--- JDBC driver class. -->
+<!ELEMENT class EMPTY>
+<!ATTLIST class
+    value CDATA #REQUIRED
+  >
+  
+<!--- URLs of the driver files. -->
+<!ELEMENT urls (url)*>
+  
+<!--- URL of the driver file. -->
+<!ELEMENT url EMPTY>
+<!ATTLIST url
+    value CDATA #REQUIRED
+  >

--- a/netbeans.apache.org/src/content/dtds/jdbc-driver-1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/jdbc-driver-1_1.dtd
@@ -1,0 +1,51 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- This is the JDBC driver registration file format used in 5.0. -->
+
+<!--- Description of the registered driver. -->
+<!ELEMENT driver (name,display-name,class,urls)>
+
+<!--- Programmatic name of the driver. -->
+<!ELEMENT name EMPTY>
+<!ATTLIST name
+    value CDATA #REQUIRED
+  >
+  
+<!--- Display name of the driver. -->
+<!ELEMENT display-name EMPTY>
+<!ATTLIST display-name
+    value CDATA #REQUIRED
+  >
+  
+<!--- JDBC driver class. -->
+<!ELEMENT class EMPTY>
+<!ATTLIST class
+    value CDATA #REQUIRED
+  >
+  
+<!--- URLs of the driver files. -->
+<!ELEMENT urls (url)*>
+  
+<!--- URL of the driver file. -->
+<!ELEMENT url EMPTY>
+<!ATTLIST url
+    value CDATA #REQUIRED
+  >

--- a/netbeans.apache.org/src/content/dtds/library-declaration-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/library-declaration-1_0.dtd
@@ -1,0 +1,82 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+    Declaratively describes library content definition.
+
+    PUBLIC "-//NetBeans//DTD Library Declaration 1.0//EN"
+    SYSTEM "https://netbeans.org/dtds/library-declaration-1_0.dtd"
+
+    Example:
+    <library version="1.0">
+        <type>j2se</type>
+        <name>NetBeans Lookup library</name>
+        <description>Library providing lookup functionality.</description>
+        <volume>
+            <type>classpath</type>
+            <resource>nbinst:/modules/autoload/lookup.jar</resource>
+        </volume>
+        <volume>
+            <type>javadoc</type>
+            <resource>file:/home/me/Projects/lookup/doc/standard-doclet/</resource>
+        </volume>
+    </library>
+-->
+
+<!---
+  Root element of library definition descriptor.
+-->
+<!ELEMENT library (name, type, description?, localizing-bundle?, volume*) >
+
+<!-- The version attribute specifies the version of the library -->
+<!ATTLIST library version CDATA #FIXED "1.0" >
+
+<!--- Library unique identifier - a string.
+ In the case when the localizing-bundle element presents the name value is used 
+ as a key into bundle to locate the display name. Otherwise the name value is 
+ used as a display name-->
+<!ELEMENT name (#PCDATA) >
+
+<!--Short description of given library - a string.
+ In the case when the localizing-bundle element presents the description value
+ is used as a key into bundle to locate the localized description. Otherwise
+ the description value is used.-->
+<!ELEMENT description (#PCDATA) >
+
+<!-- The resource name of base bundle without an extension - a string.
+ The bundle used to lookup the localized strings.
+ The bundle is looked up by NbBundle.getBundle (String) method.
+ Example of localizing bundle: org.netbeans.modules.junit.resources.Bundle -->
+<!ELEMENT localizing-bundle (#PCDATA)>
+
+<!--- Volume is typed list of resources -->
+<!ELEMENT volume (type, resource*) >
+
+<!--- Volume type of a library volume - a string 
+ For example the J2SE library supports the following types of volume:
+ classpath, javadoc and src -->
+<!ELEMENT type (#PCDATA) >
+
+<!--- Volume resource coded as absolute URI.
+ Example:
+ file:/usr/lib/java/xerces.jar is resolved to /usr/lib/java/xerces.jar
+ nbinst:/modules/ext/junit.jar is resolved to /IDE-INSTALLATION/ide4/modules/ext/junit.jar
+ -->
+<!ELEMENT resource (#PCDATA) >

--- a/netbeans.apache.org/src/content/dtds/mime-resolver-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/mime-resolver-1_0.dtd
@@ -1,0 +1,112 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--- 
+  MIME resolver description root element.
+  <p>
+  <samp>PUBLIC "-//NetBeans//DTD MIME Resolver 1.0//EN"</samp>
+  </p>
+-->
+<!ELEMENT MIME-resolver (file)+ >
+
+
+<!--
+  Plugin rule entities:
+-->
+<!ENTITY % xml-rules-component PUBLIC "-//NetBeans//DTD MIME Resolver XML Rules 1.0//EN" "https://netbeans.org/dtds/mime-resolver-xml-component-1_0.dtd">
+%xml-rules-component;
+
+<!--
+  Update this entity after you plug in a new component.
+  Update also the public ID version.
+  You must maintain backwards compatibility.
+-->
+<!ENTITY % components "(xml-rule)?">
+
+
+
+
+<!--- 
+  A file (resource) represents the MIME resolver input.
+  The resource is tested on attributes obtained from lower layers (OS) such
+  as extension, header bytes and wrapping <code>FileObject</code> attributes.
+  Some of them must match to proceed to the <code>resolver</code> element.
+  <p>
+  Implementation Note: 
+  Lower level MIME type is obtained by <code>FileUtil.getMIMEType()</code>. It may not be 
+  retrieved by a call to <code>FileObject.getMIMEType</code> to avoid recursion. A better way
+  to determine MIME type as assigned by the OS may be introduced in the future.
+  </p>
+  <p>
+  Implementation Note: 
+  All other tests are performed by calling appropriate methods on <code>FileObject</code>
+  so there is a danger of recursion if these call <code>this.getMIMEType()</code>.
+  </p>
+-->
+<!ELEMENT file ((ext | mime | magic | fattr)+, (resolver | exit)) >
+
+<!---
+  Tests resource extension for full equality.
+-->
+<!ELEMENT ext EMPTY>
+<!ATTLIST ext name CDATA #REQUIRED>
+
+<!---
+  Tests resource MIME type for equality (RFC2045) or suffix equality if it 
+  starts with '+' (RFC 3023). 
+-->
+<!ELEMENT mime EMPTY>
+<!ATTLIST mime name CDATA #REQUIRED>
+
+<!--- 
+  Look at initial bytes of the file and test for a complete match of masked
+  bits. The default mask is the hexadecimal byte <samp>FF</samp> repeated as
+  many times as the <code>hex</code> attribute is long.
+  E.g. <samp>&lt;magic hex="0a0001" mask="FF00FF"/&gt;</samp>
+-->
+<!ELEMENT magic EMPTY>
+<!ATTLIST magic hex CDATA #REQUIRED>
+<!ATTLIST magic mask CDATA #IMPLIED>
+
+<!---
+  Test on <code>FileObject</code> attributes. Matching attributes are converted
+  to strings via <code>Object.toString()</code> and compared to the <code>text</code>
+  attribute.
+  <p>
+  <code>FileObject</code> attributes can be used for out-of-band tagging of standard documents.
+  </p>
+-->
+<!ELEMENT fattr EMPTY>
+<!ATTLIST fattr name CDATA #REQUIRED>
+<!ATTLIST fattr text CDATA #REQUIRED>
+
+<!---
+  You may apply additional rules based on resource content.
+  The <code>mime</code> element value is returned. Use the reserved value of <code>null</code>
+  to indicate you are not interested in such files (same as <samp>&lt;exit/&gt;</samp>).
+-->
+<!ELEMENT resolver %components;>
+<!ATTLIST resolver mime CDATA #REQUIRED>
+
+<!--- 
+  Declares that this file is not recognized by this resolver. 
+  A shortcut for <samp>&lt;resolver mime="null"/&gt;</samp>.
+-->
+<!ELEMENT exit EMPTY>

--- a/netbeans.apache.org/src/content/dtds/mime-resolver-1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/mime-resolver-1_1.dtd
@@ -1,0 +1,181 @@
+<?xml encoding="UTF-8" ?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<!---
+  MIME resolver description root element.
+  <p>
+  <samp>PUBLIC "-//NetBeans//DTD MIME Resolver 1.1//EN"</samp>
+  </p>
+-->
+<!ELEMENT MIME-resolver (file)+ >
+
+
+<!--
+  Plugin rule entities:
+-->
+<!ENTITY % xml-rules-component PUBLIC "-//NetBeans//DTD MIME Resolver XML Rules 1.0//EN" "https://netbeans.org/dtds/mime-resolver-xml-component-1_0.dtd">
+%xml-rules-component;
+
+<!--
+  Update this entity after you plug in a new component.
+  Update also the public ID version.
+  You must maintain backwards compatibility.
+-->
+<!ENTITY % components "(xml-rule)?">
+
+
+
+
+<!--- 
+  A file (resource) represents the MIME resolver input.
+  The resource is tested on attributes obtained from lower layers (OS) such
+  as extension, header bytes and wrapping <code>FileObject</code> attributes.
+  Some of them must match to proceed to the <code>resolver</code> element.
+  <p>
+  Implementation Note: 
+  Lower level MIME type is obtained by <code>FileUtil.getMIMEType()</code>. It may not be 
+  retrieved by a call to <code>FileObject.getMIMEType</code> to avoid recursion. A better way
+  to determine MIME type as assigned by the OS may be introduced in the future.
+  </p>
+  <p>
+  Implementation Note: 
+  All other tests are performed by calling appropriate methods on <code>FileObject</code>
+  so there is a danger of recursion if these call <code>this.getMIMEType()</code>.
+  </p>
+-->
+<!ELEMENT file ((ext | mime | magic | fattr | pattern | name)+, (resolver | exit)) >
+
+<!---
+  Tests resource extension for full equality. If name attribute is empty string
+  (name=""), it matches all files without extension.
+-->
+<!ELEMENT ext EMPTY>
+<!ATTLIST ext name CDATA #REQUIRED>
+
+<!---
+  Tests resource MIME type for equality (RFC2045) or suffix equality if it 
+  starts with '+' (RFC 3023). 
+-->
+<!ELEMENT mime EMPTY>
+<!ATTLIST mime name CDATA #REQUIRED>
+
+<!--- 
+  Look at initial bytes of the file and test for a complete match of masked
+  bits. The default mask is the hexadecimal byte <samp>FF</samp> repeated as
+  many times as the <code>hex</code> attribute is long.
+  E.g. <samp>&lt;magic hex="0a0001" mask="FF00FF"/&gt;</samp>
+-->
+<!ELEMENT magic EMPTY>
+<!ATTLIST magic hex CDATA #REQUIRED>
+<!ATTLIST magic mask CDATA #IMPLIED>
+
+<!---
+  Test on <code>FileObject</code> attributes. Matching attributes are converted
+  to strings via <code>Object.toString()</code> and compared to the <code>text</code>
+  attribute.
+  <p>
+  <code>FileObject</code> attributes can be used for out-of-band tagging of standard documents.
+  </p>
+-->
+<!ELEMENT fattr EMPTY>
+<!ATTLIST fattr name CDATA #REQUIRED>
+<!ATTLIST fattr text CDATA #REQUIRED>
+
+<!---
+  Search in the file for given pattern in given range. If there is an inner
+  pattern element, it is used only if outer is fulfilled. Searching starts
+  always from the beginning of the file. For example:
+  <p>
+  Pattern &lt;?php in first 255 bytes
+  <pre>
+    &lt;pattern value="&lt;?php" range="255"/&gt;
+  </pre>
+  </p>
+  <p>
+  Pattern &lt;HTML&gt; or &lt;html&gt; in first 255 bytes and pattern &lt;?php in first 4000 bytes.
+  <pre>
+    &lt;pattern value="&lt;HTML&gt;" range="255" ignorecase="true"&gt;
+        &lt;pattern value="&lt;?php" range="4000"/&gt;
+    &lt;/pattern&gt;
+  </pre>
+  </p>
+-->
+<!ELEMENT pattern (pattern?) >
+<!-- Pattern to search for. It doesn't support wildcards or regular expressions. -->
+<!ATTLIST pattern value CDATA #REQUIRED>
+<!-- Range in bytes from beginning of the file. -->
+<!ATTLIST pattern range CDATA #REQUIRED>
+<!-- Whether search is case sensitive. By default it is case sensitive, i.e. ignorecase=false. -->
+<!ATTLIST pattern ignorecase CDATA #IMPLIED>
+
+<!---
+  Compare filename with given name.
+  For example:
+  <p>
+  Filename matches makefile, Makefile, MaKeFiLe, mymakefile, gnumakefile, makefile1, ....
+  <pre>
+    &lt;name name="makefile" substring="true"/&gt;
+  </pre>
+  </p>
+  <p>
+  Filename exactly matches rakefile or Rakefile.
+  <pre>
+    &lt;name name="rakefile" ignorecase="false"/&gt;
+    &lt;name name="Rakefile" ignorecase="false"/&gt;
+  </pre>
+  </p>
+-->
+<!ELEMENT name EMPTY>
+<!-- Filename to search for. It doesn't support wildcards or regular expressions. -->
+<!ATTLIST name name CDATA #REQUIRED>
+<!-- Whether to search for substring or exact match. Default is exact match, i.e. substring=false. -->
+<!ATTLIST name substring CDATA #IMPLIED>
+<!-- Whether search is case sensitive. By default it is case insensitive, i.e. ignorecase=true. -->
+<!ATTLIST name ignorecase CDATA #IMPLIED>
+
+<!---
+  You may apply additional rules based on resource content.
+  The <code>mime</code> element value is returned. Use the reserved value of <code>null</code>
+  to indicate you are not interested in such files (same as <samp>&lt;exit/&gt;</samp>).
+-->
+<!ELEMENT resolver %components;>
+<!ATTLIST resolver mime CDATA #REQUIRED>
+
+<!---
+  Declares that this file is not recognized by this resolver. 
+  A shortcut for <samp>&lt;resolver mime="null"/&gt;</samp>.
+  For example:
+  <p>
+  Do not resolve *.txt files and do time consuming magic recognition only for not-txt files.
+  <pre>
+    &lt;file&gt;
+      &lt;ext name="txt"/&gt;
+      &lt;exit/&gt;
+    &lt;/file&gt;
+    &lt;file&gt;
+      &lt;magic hex="0a0001" mask="FF00FF"/&gt;
+      &lt;resolver mime="text/plain"/&gt;
+    &lt;/file&gt;
+  </pre>
+  </p>
+-->
+<!ELEMENT exit EMPTY>

--- a/netbeans.apache.org/src/content/dtds/mime-resolver-xml-component-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/mime-resolver-xml-component-1_0.dtd
@@ -1,0 +1,95 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!---
+  MIME component checking XML resource header, permitting matches against
+  XML constructs: processing instructions, document type declarations, and root element (start tag).
+  <p>
+  <samp>PUBLIC "-//NetBeans//DTD MIME Resolver XML Rules 1.0//EN"</samp>
+  </p>
+  It should work well for:
+  <dl>
+  <dt>Well-formed document type detection</dt>
+  <dd>Using: PIs, root element name and root element attributes.</dd>
+  <dt>DTD-constrained document detection</dt>
+  <dd>Using: PIs and DOCTYPE public IDs.</dd>
+  <dt>NS-constrained documents</dt>
+  <dd>Using: PIs and root element namespaces.</dd>
+  </dl>
+-->
+<!ELEMENT xml-rule (pi*, doctype?, element?)>
+
+<!---
+  Processing instructions can be tested on target and pseudo-attributes.
+  <p>
+  It should be used for in-band tagging that is specified by some
+  accepted specification. For NetBeans-specific tagging of third party standards it is
+  recommended to use out-of-band tagging such as <code>FileObject</code> attributes.
+  </p>
+-->
+<!ELEMENT pi (attr*) >
+<!ATTLIST pi target CDATA #REQUIRED>
+
+<!---
+  Match one of the DOCTYPE's public IDs.
+  Use of <code>public-id</code> subelements is mutually exclusive with the attribute.
+-->
+<!ELEMENT doctype (public-id*) >
+<!ATTLIST doctype public-id CDATA #IMPLIED>
+
+<!---
+  A public ID is checked for an exact match.
+-->
+<!ELEMENT public-id EMPTY>
+<!ATTLIST public-id id CDATA #REQUIRED>
+
+<!---
+  Matches a root element by specified name, attributes or namespace.
+  <p>
+  The namespace <code>ns</code> attribute or the presence of any <code>ns</code> subelements 
+  implies that the <code>name</code> attribute represents a local element name,
+  otherwise the <code>name</code> attribute represents a full element name ("QName").
+  One of the namespaces must match.
+  </p>
+-->
+<!ELEMENT element (ns*, attr*)>
+<!ATTLIST element ns CDATA #IMPLIED>
+<!ATTLIST element name CDATA #IMPLIED>
+
+<!---
+  Test namespace equality (exact match).
+-->
+<!ELEMENT ns EMPTY>
+<!ATTLIST ns ns CDATA #REQUIRED>
+
+
+<!---
+  Element attribute template, also used for pseudo-attributes in processing instructions.
+  <p>
+  The <code>name</code> attribute contains the full attribute name (QName).
+  This is inteded to be used for documents that cannot be indentified by public ID nor
+  root element namespace.
+  </p>
+  If <code>text</code> is specified then the attribute's normalized text must
+  exactly match the specified text, otherwise the attribute just needs to be present.
+-->
+<!ELEMENT attr EMPTY>
+<!ATTLIST attr name CDATA #REQUIRED>
+<!ATTLIST attr text CDATA #IMPLIED>

--- a/netbeans.apache.org/src/content/dtds/mode-properties1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/mode-properties1_0.dtd
@@ -1,0 +1,170 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Mode Properties 1.0//EN
+-->
+
+<!-- The root element for mode properties. Consists of name, optional
+     module information and several property sets for various types of
+     user interface.
+     Atribute "version" is optional versioning attribute, which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT mode (name, description?, module?, ui-type+) >
+<!ATTLIST mode
+    version CDATA #IMPLIED
+>
+
+<!-- User interface type element, holds mode property set for specific type
+    of user interface. UI type is identified by its only attribute "type",
+    Value "any" is special value which is reserved for default setting set which
+    is used when property set for specific ui-type is not found. Thus, simplest variant is to
+    define only one property set with type "any", which means that for all
+    types of user interface mode will have same properties. -->
+<!ELEMENT ui-type ((bounds | relative-bounds), frame, container, icon?, other?) >
+<!ATTLIST ui-type
+    type (sdi | mdi | any) #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of mode defined by module if module is unistalled.
+    If you want your module's mode to be unistalled automatically when
+    your module is deinstalled, fill this element. When this element is missing,
+    no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!-- Element name has four attributes
+    1) "unique" represents UID of mode unique in context of surrounding workspace
+    2) "display" represents optional display name of the mode.
+       If display name is not specified, unique name is used as display name
+       too. If "from-bundle" flag is enabled, this attribute must contain
+       bundle key where to find localized display name. (example value: "CTL_MyModeName")
+    3) "from-bundle" flag to control if display name is taken from bundle or not
+    4) "bundle" identifies bundle from which localized display name will be read.
+       Format is the same like for fully qualified classes. For example, 
+       localization bundle named "Bundle" in package "my.package" can be pointed
+       to by value "my.package.Bundle".
+       Attributes "bundle" and "display" together give fully qualified bundle
+       pointer. This attribute is optional, has no meaning if "from-bundle" is false
+-->
+<!ELEMENT name      EMPTY >
+<!ATTLIST name
+    unique CDATA #REQUIRED
+    display CDATA #IMPLIED
+    from-bundle (true | false) #IMPLIED
+    bundle CDATA #IMPLIED
+>
+
+<!-- Optional element description has two attributes
+    1) "display" represents bundle key where to find localized 
+        mode description. (example value: "CTL_MyModeDescription")
+    2) "bundle" identifies bundle from which localized description will be read.
+       Format is the same like for fully qualified classes. For example, 
+       localization bundle named "Bundle" in package "my.package" can be pointed
+       to by value "my.package.Bundle".
+       Attributes "bundle" and "display" together give fully qualified bundle
+       pointer.
+-->
+<!ELEMENT description EMPTY >
+<!ATTLIST description
+    display CDATA #REQUIRED
+    bundle CDATA #REQUIRED
+>
+
+<!-- Relative (percentage) bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds 
+     rectangle, it is relative to desktopi: size of main window (mdi) or width 
+     of main window and height of area bellow main window.
+-->
+<!ELEMENT relative-bounds    EMPTY >
+<!ATTLIST relative-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Frame properties. Attribute "type" represents type of frame, possible values:
+    "window" = standalone frame, used in SDI ui mode
+    "internal" = frame floating in MDI desktop
+    "desktop" = frame attached to side of main window in MDI mode
+    "dialog" = standalone dialog (for future, not implemented yet)
+    Attribute "state" represents iconfified, maximized or normal state of frame,
+    attribute "constraints" stores position of frame inside main window,
+    to which side is attached, valid only for desktop type of frames
+-->
+<!ELEMENT frame    EMPTY >
+<!ATTLIST frame
+    type (window | internal | desktop | dialog) #REQUIRED
+    constraints (center | left | right | top | bottom) #IMPLIED
+    state (normal | iconified  | maximized) #IMPLIED
+>
+
+<!-- Container properties. Required attribute "type" represents type of container,
+     "active" stores reference to top component which was active (should receive
+     focus when frame is activated)
+-->
+<!ELEMENT container  (area*) >
+<!ATTLIST container
+    type (split | tabbed) #REQUIRED
+    active-tc CDATA #IMPLIED
+>
+
+<!-- Area properties describe properties of panes in split frame.
+     "constraint" gives location of pane,
+     "x","y","width","height" relative bounds of area in mode (frame), valid values
+     are from 0 to 100 because areas are always inside of frame.
+-->
+<!ELEMENT area   EMPTY >
+<!ATTLIST area
+    constraint (center | left | right | top | bottom) #REQUIRED
+    relative-x CDATA #REQUIRED
+    relative-y CDATA #REQUIRED
+    relative-width CDATA #REQUIRED
+    relative-height CDATA #REQUIRED
+>
+
+<!-- Icon properties, just url, not required. -->
+<!ELEMENT icon   EMPTY >
+<!ATTLIST icon
+    url CDATA #IMPLIED
+>
+
+<!-- Other, now used only for distinction between modes created by user and 
+     created by modules, optional.
+     "mode-state" is "visible" when mode contains at least one opened top component
+     and "hidden" when mode is empty or contains only closed top components -->
+<!ELEMENT other   EMPTY >
+<!ATTLIST other
+    defined-by (module | user) #IMPLIED
+    mode-state (visible | hidden) #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/mode-properties1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/mode-properties1_1.dtd
@@ -1,0 +1,194 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Mode Properties 1.1//EN
+-->
+
+<!-- The root element for mode properties. Consists of name, optional
+     module information and several property sets for various types of
+     user interface.
+     Atribute "version" is optional versioning attribute, which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT mode (name, description?, module?, ui-type+) >
+<!ATTLIST mode
+    version CDATA #IMPLIED
+>
+
+<!-- User interface type element, holds mode property set for specific type
+    of user interface. UI type is identified by its only attribute "type",
+    Value "any" is special value which is reserved for default setting set which
+    is used when property set for specific ui-type is not found. Thus, simplest variant is to
+    define only one property set with type "any", which means that for all
+    types of user interface mode will have same properties. -->
+<!ELEMENT ui-type (((bounds, maximized-bounds?) | relative-bounds), frame, container, icon?, other?) >
+<!ATTLIST ui-type
+    type (sdi | mdi | any) #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of mode defined by module if module is unistalled.
+    If you want your module's mode to be unistalled automatically when
+    your module is deinstalled, fill this element. When this element is missing,
+    no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!-- Element name has four attributes
+    1) "unique" represents UID of mode unique in context of surrounding workspace
+    2) "display" represents optional display name of the mode.
+       If display name is not specified, unique name is used as display name
+       too. If "from-bundle" flag is enabled, this attribute must contain
+       bundle key where to find localized display name. (example value: "CTL_MyModeName")
+    3) "from-bundle" flag to control if display name is taken from bundle or not
+    4) "bundle" identifies bundle from which localized display name will be read.
+       Format is the same like for fully qualified classes. For example, 
+       localization bundle named "Bundle" in package "my.package" can be pointed
+       to by value "my.package.Bundle".
+       Attributes "bundle" and "display" together give fully qualified bundle
+       pointer. This attribute is optional, has no meaning if "from-bundle" is false
+-->
+<!ELEMENT name      EMPTY >
+<!ATTLIST name
+    unique CDATA #REQUIRED
+    display CDATA #IMPLIED
+    from-bundle (true | false) #IMPLIED
+    bundle CDATA #IMPLIED
+>
+
+<!-- Optional element description has two attributes
+    1) "display" represents bundle key where to find localized 
+        mode description. (example value: "CTL_MyModeDescription")
+    2) "bundle" identifies bundle from which localized description will be read.
+       Format is the same like for fully qualified classes. For example, 
+       localization bundle named "Bundle" in package "my.package" can be pointed
+       to by value "my.package.Bundle".
+       Attributes "bundle" and "display" together give fully qualified bundle
+       pointer.
+-->
+<!ELEMENT description EMPTY >
+<!ATTLIST description
+    display CDATA #REQUIRED
+    bundle CDATA #REQUIRED
+>
+
+<!-- Absolute bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds 
+     rectangle.
+-->
+<!ELEMENT bounds    EMPTY >
+<!ATTLIST bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Absolute bounds rectangle of the maximized mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle.
+-->
+<!ELEMENT maximized-bounds    EMPTY >
+<!ATTLIST maximized-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Relative (percentage) bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle, it is relative to desktop size of main window (mdi) or width
+     of main window and height of area bellow main window.
+-->
+<!ELEMENT relative-bounds    EMPTY >
+<!ATTLIST relative-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Frame properties. Attribute "type" represents type of frame, possible values:
+    "window" = standalone frame, used in SDI ui mode
+    "internal" = frame floating in MDI desktop
+    "desktop" = frame attached to side of main window in MDI mode
+    "dialog" = standalone dialog (for future, not implemented yet)
+    Attribute "state" represents iconfified, maximized or normal state of frame,
+    attribute "constraints" stores position of frame inside main window,
+    to which side is attached, valid only for desktop type of frames
+-->
+<!ELEMENT frame    EMPTY >
+<!ATTLIST frame
+    type (window | internal | desktop | dialog) #REQUIRED
+    constraints (center | left | right | top | bottom) #IMPLIED
+    state (normal | iconified  | maximized) #IMPLIED
+>
+
+<!-- Container properties. Required attribute "type" represents type of container,
+     "active" stores reference to top component which was active (should receive
+     focus when frame is activated)
+-->
+<!ELEMENT container  (area*) >
+<!ATTLIST container
+    type (split | tabbed) #REQUIRED
+    active-tc CDATA #IMPLIED
+>
+
+<!-- Area properties describe properties of panes in split frame.
+     "constraint" gives location of pane,
+     "x","y","width","height" relative bounds of area in mode (frame), valid values
+     are from 0 to 100 because areas are always inside of frame.
+-->
+<!ELEMENT area   EMPTY >
+<!ATTLIST area
+    constraint (center | left | right | top | bottom) #REQUIRED
+    relative-x CDATA #REQUIRED
+    relative-y CDATA #REQUIRED
+    relative-width CDATA #REQUIRED
+    relative-height CDATA #REQUIRED
+>
+
+<!-- Icon properties, just url, not required. -->
+<!ELEMENT icon   EMPTY >
+<!ATTLIST icon
+    url CDATA #IMPLIED
+>
+
+<!-- Other, now used only for distinction between modes created by user and 
+     created by modules, optional.
+     "mode-state" is "visible" when mode contains at least one opened top component
+     and "hidden" when mode is empty or contains only closed top components -->
+<!ELEMENT other   EMPTY >
+<!ATTLIST other
+    defined-by (module | user) #IMPLIED
+    mode-state (visible | hidden) #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/mode-properties1_2.dtd
+++ b/netbeans.apache.org/src/content/dtds/mode-properties1_2.dtd
@@ -1,0 +1,198 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Mode Properties 1.2//EN
+-->
+
+<!-- The root element for mode properties. Consists of name, optional
+     module information and several property sets for various types of
+     user interface.
+     Atribute "version" is optional versioning attribute, which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT mode (name, description?, module?, ui-type+) >
+<!ATTLIST mode
+    version CDATA #IMPLIED
+>
+
+<!-- User interface type element, holds mode property set for specific type
+    of user interface. UI type is identified by its only attribute "type",
+    Value "any" is special value which is reserved for default setting set which
+    is used when property set for specific ui-type is not found. Thus, simplest variant is to
+    define only one property set with type "any", which means that for all
+    types of user interface mode will have same properties. -->
+<!ELEMENT ui-type (((bounds, maximized-bounds?) | relative-bounds), frame, container, icon?, other?) >
+<!ATTLIST ui-type
+    type (sdi | mdi | any) #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of mode defined by module if module is unistalled.
+    If you want your module's mode to be unistalled automatically when
+    your module is deinstalled, fill this element. When this element is missing,
+    no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!-- Element name has four attributes
+    1) "unique" represents UID of mode unique in context of surrounding workspace
+    2) "display" represents optional display name of the mode.
+       If display name is not specified, unique name is used as display name
+       too. If "from-bundle" flag is enabled, this attribute must contain
+       bundle key where to find localized display name. (example value: "CTL_MyModeName")
+    3) "from-bundle" flag to control if display name is taken from bundle or not
+    4) "bundle" identifies bundle from which localized display name will be read.
+       Format is the same like for fully qualified classes. For example, 
+       localization bundle named "Bundle" in package "my.package" can be pointed
+       to by value "my.package.Bundle".
+       Attributes "bundle" and "display" together give fully qualified bundle
+       pointer. This attribute is optional, has no meaning if "from-bundle" is false
+-->
+<!ELEMENT name      EMPTY >
+<!ATTLIST name
+    unique CDATA #REQUIRED
+    display CDATA #IMPLIED
+    from-bundle (true | false) #IMPLIED
+    bundle CDATA #IMPLIED
+>
+
+<!-- Optional element description has two attributes
+    1) "display" represents bundle key where to find localized 
+        mode description. (example value: "CTL_MyModeDescription")
+    2) "bundle" identifies bundle from which localized description will be read.
+       Format is the same like for fully qualified classes. For example, 
+       localization bundle named "Bundle" in package "my.package" can be pointed
+       to by value "my.package.Bundle".
+       Attributes "bundle" and "display" together give fully qualified bundle
+       pointer.
+-->
+<!ELEMENT description EMPTY >
+<!ATTLIST description
+    display CDATA #REQUIRED
+    bundle CDATA #REQUIRED
+>
+
+<!-- Absolute bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds 
+     rectangle.
+-->
+<!ELEMENT bounds    EMPTY >
+<!ATTLIST bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Absolute bounds rectangle of the maximized mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle.
+-->
+<!ELEMENT maximized-bounds    EMPTY >
+<!ATTLIST maximized-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Relative (percentage) bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle, it is relative to desktop size of main window (mdi) or width
+     of main window and height of area bellow main window.
+-->
+<!ELEMENT relative-bounds    EMPTY >
+<!ATTLIST relative-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Frame properties. Attribute "type" represents type of frame, possible values:
+    "window" = standalone frame, used in SDI ui mode
+    "internal" = frame floating in MDI desktop
+    "desktop" = frame attached to side of main window in MDI mode
+    "dialog" = standalone dialog (for future, not implemented yet)
+    Attribute "state" represents current state of frame. It can be iconfified, maximized 
+    or normal.
+    Attribute "restored-state" represents current state of frame when restored. It is valid only
+    when attribute "state" is maximized. 
+    Attribute "constraints" stores position of frame inside main window,
+    to which side is attached, valid only for desktop type of frames
+-->
+<!ELEMENT frame    EMPTY >
+<!ATTLIST frame
+    type (window | internal | desktop | dialog) #REQUIRED
+    constraints (center | left | right | top | bottom) #IMPLIED
+    state (normal | iconified  | maximized) #IMPLIED
+    restored-state (normal | iconified) #IMPLIED
+>
+
+<!-- Container properties. Required attribute "type" represents type of container,
+     "active" stores reference to top component which was active (should receive
+     focus when frame is activated)
+-->
+<!ELEMENT container  (area*) >
+<!ATTLIST container
+    type (split | tabbed) #REQUIRED
+    active-tc CDATA #IMPLIED
+>
+
+<!-- Area properties describe properties of panes in split frame.
+     "constraint" gives location of pane,
+     "x","y","width","height" relative bounds of area in mode (frame), valid values
+     are from 0 to 100 because areas are always inside of frame.
+-->
+<!ELEMENT area   EMPTY >
+<!ATTLIST area
+    constraint (center | left | right | top | bottom) #REQUIRED
+    relative-x CDATA #REQUIRED
+    relative-y CDATA #REQUIRED
+    relative-width CDATA #REQUIRED
+    relative-height CDATA #REQUIRED
+>
+
+<!-- Icon properties, just url, not required. -->
+<!ELEMENT icon   EMPTY >
+<!ATTLIST icon
+    url CDATA #IMPLIED
+>
+
+<!-- Other, now used only for distinction between modes created by user and 
+     created by modules, optional.
+     "mode-state" is "visible" when mode contains at least one opened top component
+     and "hidden" when mode is empty or contains only closed top components -->
+<!ELEMENT other   EMPTY >
+<!ATTLIST other
+    defined-by (module | user) #IMPLIED
+    mode-state (visible | hidden) #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/mode-properties2_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/mode-properties2_0.dtd
@@ -1,0 +1,166 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Mode Properties 2.0//EN
+-->
+
+<!-- The root element for mode properties. Consists of name, optional
+     module information and several property sets for various types of
+     user interface.
+     Attribute "version" is versioning attribute which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT mode (module?, name, kind, state, constraints?, (bounds | relative-bounds)?, frame?, active-tc?, empty-behavior?) >
+<!ATTLIST mode
+    version CDATA #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of mode defined by module if module is disabled.
+    If you want your module's mode to be removed automatically when
+    your module is disabled, fill this element. When this element is missing,
+    no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!-- Element name
+    "unique" represents unique ID of mode
+-->
+<!ELEMENT name      EMPTY >
+<!ATTLIST name
+    unique CDATA #REQUIRED
+>
+
+<!-- Element kind
+    "type" kind of mode "editor" or "view".
+-->
+<!ELEMENT kind      EMPTY >
+<!ATTLIST kind
+    type (editor | view) #REQUIRED
+>
+
+<!-- Element state
+    "type" state of mode "joined" (is inside of main window) or "separated" 
+    (is in its own native window separated from main window).
+-->
+<!ELEMENT state      EMPTY >
+<!ATTLIST state
+    type (joined | separated) #REQUIRED
+>
+
+<!-- Absolute bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds 
+     rectangle.
+     Relevant only for separate mode (window).
+-->
+<!ELEMENT bounds    EMPTY >
+<!ATTLIST bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Relative (percentage) bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle, it is relative to width of main window and height of area below
+     main window.
+     Relevant only for separate mode (window).
+-->
+<!ELEMENT relative-bounds    EMPTY >
+<!ATTLIST relative-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Frame properties.
+    Relevant only for separate mode (window).
+    Attribute "state" represents current state of frame.
+    It is represented as bitwise mask - integer value.
+    See java.awt.Frame for possible values.
+    Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT frame    EMPTY >
+<!ATTLIST frame
+    state CDATA #IMPLIED
+>
+
+<!-- Constraints describes path of mode in model tree.
+     Path consists of array of values to describe path eg. [H1;V2].
+     Relevant only for mode inside desktop
+-->
+<!ELEMENT constraints  (path*) >
+<!ATTLIST constraints
+>
+
+<!-- Path describe path to mode in model tree.
+     "orientation" sets orientation of splitter. "horizontal" means splitting
+     along x axis - components are from left to right. "vertical" means splitting
+     along y axis - components are from top to bottom.
+     "number" sets number of cell in given split cell. It is integer number. Number defines
+     position of given cell in array of cells. It is possible to define for example
+     20 for first cell and 40 for second cell. Later it is possible to insert third cell between
+     first and second by using 30 for third cell. It is usefull for platform to allow third party
+     modules to modify (insert) their own modes to existing layout.
+     Cells are counted from left to right in case of vertical split and
+     from top to bottom in case of horizontal split.
+     "weight" is double number from 0 to 1. It sets relative size of cell
+     in given splitter. Default value is 0.5.
+-->
+<!ELEMENT path   EMPTY >
+<!ATTLIST path
+    orientation (horizontal | vertical) #REQUIRED
+    number CDATA #REQUIRED
+    weight CDATA #IMPLIED
+>
+
+<!-- Active TopComponent.
+     "id" stores unique ID of active TopComponent
+-->
+<!ELEMENT active-tc  EMPTY >
+<!ATTLIST active-tc
+    id CDATA #IMPLIED
+>
+
+<!-- Element "empty-behavior" describes behavior of mode when it is empty ie. does not contain
+     any opened TopComponent.
+     Attribute "permanent" can be "true" of "false". "true" means that mode remains in window
+     system when it is empty ie. it does not contain any opened TopComponent. "false" means that
+     mode is completely destroyed when it is empty. 
+     Optional attribute, default value is "true".
+     When mode is defined in module layer it is usually permanent ie. "true" is used.
+-->
+<!ELEMENT empty-behavior   EMPTY >
+<!ATTLIST empty-behavior
+    permanent (true | false) #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/mode-properties2_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/mode-properties2_1.dtd
@@ -1,0 +1,175 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Mode Properties 2.0//EN
+-->
+
+<!-- The root element for mode properties. Consists of name, optional
+     module information and several property sets for various types of
+     user interface.
+     Attribute "version" is versioning attribute which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT mode (module?, name, kind, slidingSide?, state, constraints?, (bounds | relative-bounds)?, frame?, active-tc?, empty-behavior?) >
+<!ATTLIST mode
+    version CDATA #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of mode defined by module if module is disabled.
+    If you want your module's mode to be removed automatically when
+    your module is disabled, fill this element. When this element is missing,
+    no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!-- Element name
+    "unique" represents unique ID of mode
+-->
+<!ELEMENT name      EMPTY >
+<!ATTLIST name
+    unique CDATA #REQUIRED
+>
+
+<!-- Element kind
+    "type" kind of mode "editor" or "view" or "sliding".
+-->
+<!ELEMENT kind      EMPTY >
+<!ATTLIST kind
+    type (editor | view | sliding) #REQUIRED
+>
+
+<!-- Element sliding side
+    "side" direction of slide
+-->
+<!ELEMENT slidingSide      EMPTY >
+<!ATTLIST slidingSide
+    side (left | right | bottom) #REQUIRED
+>
+
+
+<!-- Element state
+    "type" state of mode "joined" (is inside of main window) or "separated" 
+    (is in its own native window separated from main window).
+-->
+<!ELEMENT state      EMPTY >
+<!ATTLIST state
+    type (joined | separated) #REQUIRED
+>
+
+<!-- Absolute bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds 
+     rectangle.
+     Relevant only for separate mode (window).
+-->
+<!ELEMENT bounds    EMPTY >
+<!ATTLIST bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Relative (percentage) bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle, it is relative to width of main window and height of area below
+     main window.
+     Relevant only for separate mode (window).
+-->
+<!ELEMENT relative-bounds    EMPTY >
+<!ATTLIST relative-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Frame properties.
+    Relevant only for separate mode (window).
+    Attribute "state" represents current state of frame.
+    It is represented as bitwise mask - integer value.
+    See java.awt.Frame for possible values.
+    Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT frame    EMPTY >
+<!ATTLIST frame
+    state CDATA #IMPLIED
+>
+
+<!-- Constraints describes path of mode in model tree.
+     Path consists of array of values to describe path eg. [H1;V2].
+     Relevant only for mode inside desktop
+-->
+<!ELEMENT constraints  (path*) >
+<!ATTLIST constraints
+>
+
+<!-- Path describe path to mode in model tree.
+     "orientation" sets orientation of splitter. "horizontal" means splitting
+     along x axis - components are from left to right. "vertical" means splitting
+     along y axis - components are from top to bottom.
+     "number" sets number of cell in given split cell. It is integer number. Number defines
+     position of given cell in array of cells. It is possible to define for example
+     20 for first cell and 40 for second cell. Later it is possible to insert third cell between
+     first and second by using 30 for third cell. It is usefull for platform to allow third party
+     modules to modify (insert) their own modes to existing layout.
+     Cells are counted from left to right in case of vertical split and
+     from top to bottom in case of horizontal split.
+     "weight" is double number from 0 to 1. It sets relative size of cell
+     in given splitter. Default value is 0.5.
+-->
+<!ELEMENT path   EMPTY >
+<!ATTLIST path
+    orientation (horizontal | vertical) #REQUIRED
+    number CDATA #REQUIRED
+    weight CDATA #IMPLIED
+>
+
+<!-- Active TopComponent.
+     "id" stores unique ID of active TopComponent
+-->
+<!ELEMENT active-tc  EMPTY >
+<!ATTLIST active-tc
+    id CDATA #IMPLIED
+>
+
+<!-- Element "empty-behavior" describes behavior of mode when it is empty ie. does not contain
+     any opened TopComponent.
+     Attribute "permanent" can be "true" of "false". "true" means that mode remains in window
+     system when it is empty ie. it does not contain any opened TopComponent. "false" means that
+     mode is completely destroyed when it is empty. 
+     Optional attribute, default value is "true".
+     When mode is defined in module layer it is usually permanent ie. "true" is used.
+-->
+<!ELEMENT empty-behavior   EMPTY >
+<!ATTLIST empty-behavior
+    permanent (true | false) #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/mode-properties2_2.dtd
+++ b/netbeans.apache.org/src/content/dtds/mode-properties2_2.dtd
@@ -1,0 +1,185 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Mode Properties 2.2//EN
+-->
+
+<!-- The root element for mode properties. Consists of name, optional
+     module information and several property sets for various types of
+     user interface.
+     Attribute "version" is versioning attribute which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT mode (module?, name, kind, state, constraints?, (bounds | relative-bounds)?, frame?, active-tc?, empty-behavior?, slidingSide?, slideInSize*) >
+<!ATTLIST mode
+    version CDATA #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of mode defined by module if module is disabled.
+    If you want your module's mode to be removed automatically when
+    your module is disabled, fill this element. When this element is missing,
+    no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!-- Element name
+    "unique" represents unique ID of mode
+-->
+<!ELEMENT name      EMPTY >
+<!ATTLIST name
+    unique CDATA #REQUIRED
+>
+
+<!-- Element kind
+    "type" kind of mode "editor" or "view" or "sliding".
+-->
+<!ELEMENT kind      EMPTY >
+<!ATTLIST kind
+    type (editor | view | sliding) #REQUIRED
+>
+
+<!-- Element sliding side
+    "side" direction of slide
+-->
+<!ELEMENT slidingSide      EMPTY >
+<!ATTLIST slidingSide
+    side (left | right | bottom) #REQUIRED
+>
+
+
+<!-- Element slide-in size
+    "tc-id" TopComponent's ID
+    "size" the size of the TopComponent (width or height) when it is slided-in
+-->
+<!ELEMENT slideInSize      EMPTY >
+<!ATTLIST slideInSize
+    tc-id CDATA #REQUIRED
+    size CDATA #REQUIRED
+>
+
+<!-- Element state
+    "type" state of mode "joined" (is inside of main window) or "separated" 
+    (is in its own native window separated from main window).
+-->
+<!ELEMENT state      EMPTY >
+<!ATTLIST state
+    type (joined | separated) #REQUIRED
+>
+
+<!-- Absolute bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds 
+     rectangle.
+     Relevant only for separate mode (window).
+-->
+<!ELEMENT bounds    EMPTY >
+<!ATTLIST bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Relative (percentage) bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle, it is relative to width of main window and height of area below
+     main window.
+     Relevant only for separate mode (window).
+-->
+<!ELEMENT relative-bounds    EMPTY >
+<!ATTLIST relative-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Frame properties.
+    Relevant only for separate mode (window).
+    Attribute "state" represents current state of frame.
+    It is represented as bitwise mask - integer value.
+    See java.awt.Frame for possible values.
+    Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT frame    EMPTY >
+<!ATTLIST frame
+    state CDATA #IMPLIED
+>
+
+<!-- Constraints describes path of mode in model tree.
+     Path consists of array of values to describe path eg. [H1;V2].
+     Relevant only for mode inside desktop
+-->
+<!ELEMENT constraints  (path*) >
+<!ATTLIST constraints
+>
+
+<!-- Path describe path to mode in model tree.
+     "orientation" sets orientation of splitter. "horizontal" means splitting
+     along x axis - components are from left to right. "vertical" means splitting
+     along y axis - components are from top to bottom.
+     "number" sets number of cell in given split cell. It is integer number. Number defines
+     position of given cell in array of cells. It is possible to define for example
+     20 for first cell and 40 for second cell. Later it is possible to insert third cell between
+     first and second by using 30 for third cell. It is usefull for platform to allow third party
+     modules to modify (insert) their own modes to existing layout.
+     Cells are counted from left to right in case of vertical split and
+     from top to bottom in case of horizontal split.
+     "weight" is double number from 0 to 1. It sets relative size of cell
+     in given splitter. Default value is 0.5.
+-->
+<!ELEMENT path   EMPTY >
+<!ATTLIST path
+    orientation (horizontal | vertical) #REQUIRED
+    number CDATA #REQUIRED
+    weight CDATA #IMPLIED
+>
+
+<!-- Active TopComponent.
+     "id" stores unique ID of active TopComponent
+-->
+<!ELEMENT active-tc  EMPTY >
+<!ATTLIST active-tc
+    id CDATA #IMPLIED
+>
+
+<!-- Element "empty-behavior" describes behavior of mode when it is empty ie. does not contain
+     any opened TopComponent.
+     Attribute "permanent" can be "true" of "false". "true" means that mode remains in window
+     system when it is empty ie. it does not contain any opened TopComponent. "false" means that
+     mode is completely destroyed when it is empty. 
+     Optional attribute, default value is "true".
+     When mode is defined in module layer it is usually permanent ie. "true" is used.
+-->
+<!ELEMENT empty-behavior   EMPTY >
+<!ATTLIST empty-behavior
+    permanent (true | false) #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/mode-properties2_3.dtd
+++ b/netbeans.apache.org/src/content/dtds/mode-properties2_3.dtd
@@ -1,0 +1,186 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Mode Properties 2.3//EN
+-->
+
+<!-- The root element for mode properties. Consists of name, optional
+     module information and several property sets for various types of
+     user interface.
+     Attribute "version" is versioning attribute which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT mode (module?, name, kind, state, constraints?, (bounds | relative-bounds)?, frame?, active-tc?, empty-behavior?, slidingSide?, slide-in-size*) >
+<!ATTLIST mode
+    version CDATA #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of mode defined by module if module is disabled.
+    If you want your module's mode to be removed automatically when
+    your module is disabled, fill this element. When this element is missing,
+    no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!-- Element name
+    "unique" represents unique ID of mode
+-->
+<!ELEMENT name      EMPTY >
+<!ATTLIST name
+    unique CDATA #REQUIRED
+>
+
+<!-- Element kind
+    "type" kind of mode "editor" or "view" or "sliding".
+-->
+<!ELEMENT kind      EMPTY >
+<!ATTLIST kind
+    type (editor | view | sliding) #REQUIRED
+>
+
+<!-- Element sliding side
+    "side" direction of slide
+-->
+<!ELEMENT slidingSide      EMPTY >
+<!ATTLIST slidingSide
+    side (left | right | bottom) #REQUIRED
+>
+
+
+<!-- Element slide-in size
+    "tc-id" TopComponent's ID
+    "size" the size of the TopComponent (width or height) when it is slided-in
+-->
+<!ELEMENT slide-in-size      EMPTY >
+<!ATTLIST slide-in-size
+    tc-id CDATA #REQUIRED
+    size CDATA #REQUIRED
+>
+
+<!-- Element state
+    "type" state of mode "joined" (is inside of main window) or "separated" 
+    (is in its own native window separated from main window).
+-->
+<!ELEMENT state      EMPTY >
+<!ATTLIST state
+    type (joined | separated) #REQUIRED
+>
+
+<!-- Absolute bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds 
+     rectangle.
+     Relevant only for separate mode (window).
+-->
+<!ELEMENT bounds    EMPTY >
+<!ATTLIST bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Relative (percentage) bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle, it is relative to width of main window and height of area below
+     main window.
+     Relevant only for separate mode (window).
+-->
+<!ELEMENT relative-bounds    EMPTY >
+<!ATTLIST relative-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Frame properties.
+    Relevant only for separate mode (window).
+    Attribute "state" represents current state of frame.
+    It is represented as bitwise mask - integer value.
+    See java.awt.Frame for possible values.
+    Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT frame    EMPTY >
+<!ATTLIST frame
+    state CDATA #IMPLIED
+>
+
+<!-- Constraints describes path of mode in model tree.
+     Path consists of array of values to describe path eg. [H1;V2].
+     Relevant only for mode inside desktop
+-->
+<!ELEMENT constraints  (path*) >
+<!ATTLIST constraints
+>
+
+<!-- Path describe path to mode in model tree.
+     "orientation" sets orientation of splitter. "horizontal" means splitting
+     along x axis - components are from left to right. "vertical" means splitting
+     along y axis - components are from top to bottom.
+     "number" sets number of cell in given split cell. It is integer number. Number defines
+     position of given cell in array of cells. It is possible to define for example
+     20 for first cell and 40 for second cell. Later it is possible to insert third cell between
+     first and second by using 30 for third cell. It is usefull for platform to allow third party
+     modules to modify (insert) their own modes to existing layout.
+     Cells are counted from left to right in case of vertical split and
+     from top to bottom in case of horizontal split.
+     "weight" is double number from 0 to 1. It sets relative size of cell
+     in given splitter. Default value is 0.5.
+-->
+<!ELEMENT path   EMPTY >
+<!ATTLIST path
+    orientation (horizontal | vertical) #REQUIRED
+    number CDATA #REQUIRED
+    weight CDATA #IMPLIED
+>
+
+<!-- Active TopComponent.
+     "id" stores unique ID of active TopComponent
+-->
+<!ELEMENT active-tc  EMPTY >
+<!ATTLIST active-tc
+    id CDATA #IMPLIED
+    prev-id CDATA #IMPLIED
+>
+
+<!-- Element "empty-behavior" describes behavior of mode when it is empty ie. does not contain
+     any opened TopComponent.
+     Attribute "permanent" can be "true" of "false". "true" means that mode remains in window
+     system when it is empty ie. it does not contain any opened TopComponent. "false" means that
+     mode is completely destroyed when it is empty. 
+     Optional attribute, default value is "true".
+     When mode is defined in module layer it is usually permanent ie. "true" is used.
+-->
+<!ELEMENT empty-behavior   EMPTY >
+<!ATTLIST empty-behavior
+    permanent (true | false) #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/mode-properties2_4.dtd
+++ b/netbeans.apache.org/src/content/dtds/mode-properties2_4.dtd
@@ -1,0 +1,192 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Mode Properties 2.4//EN
+-->
+
+<!-- The root element for mode properties. Consists of name, optional
+     module information and several property sets for various types of
+     user interface.
+     Attribute "version" is versioning attribute which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT mode (module?, name, kind, state, constraints?, (bounds | relative-bounds)?, frame?, active-tc?, empty-behavior?, slidingSide?, slide-in-size*) >
+<!ATTLIST mode
+    version CDATA #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of mode defined by module if module is disabled.
+    If you want your module's mode to be removed automatically when
+    your module is disabled, fill this element. When this element is missing,
+    no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!-- Element name
+    "unique" represents unique ID of mode
+    "includes" contains a list of names of other modes that were merged into this one.
+-->
+<!ELEMENT name      EMPTY >
+<!ATTLIST name
+    unique CDATA #REQUIRED
+    includes CDATA #IMPLIED
+>
+
+<!-- Element kind
+    "type" kind of mode "editor" or "view" or "sliding".
+-->
+<!ELEMENT kind      EMPTY >
+<!ATTLIST kind
+    type (editor | view | sliding) #REQUIRED
+>
+
+<!-- Element sliding side
+    "side" direction of slide
+-->
+<!ELEMENT slidingSide      EMPTY >
+<!ATTLIST slidingSide
+    side (left | right | bottom | top) #REQUIRED
+>
+
+
+<!-- Element slide-in size
+    "tc-id" TopComponent's ID
+    "size" the size of the TopComponent (width or height) when it is slided-in
+-->
+<!ELEMENT slide-in-size      EMPTY >
+<!ATTLIST slide-in-size
+    tc-id CDATA #REQUIRED
+    size CDATA #REQUIRED
+>
+
+<!-- Element state
+    "type" state of mode "joined" (is inside of main window) or "separated" 
+    (is in its own native window separated from main window).
+    "minimized" state "true" means that any window opened in this mode is
+    automatically minimized (slided out).
+-->
+<!ELEMENT state      EMPTY >
+<!ATTLIST state
+    type (joined | separated) #REQUIRED
+    minimized (true | false) #IMPLIED
+>
+
+<!-- Absolute bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds 
+     rectangle.
+     Relevant only for separate mode (window).
+-->
+<!ELEMENT bounds    EMPTY >
+<!ATTLIST bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Relative (percentage) bounds rectangle of the mode, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle, it is relative to width of main window and height of area below
+     main window.
+     Relevant only for separate mode (window).
+-->
+<!ELEMENT relative-bounds    EMPTY >
+<!ATTLIST relative-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Frame properties.
+    Relevant only for separate mode (window).
+    Attribute "state" represents current state of frame.
+    It is represented as bitwise mask - integer value.
+    See java.awt.Frame for possible values.
+    Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT frame    EMPTY >
+<!ATTLIST frame
+    state CDATA #IMPLIED
+>
+
+<!-- Constraints describes path of mode in model tree.
+     Path consists of array of values to describe path eg. [H1;V2].
+     Relevant only for mode inside desktop
+-->
+<!ELEMENT constraints  (path*) >
+<!ATTLIST constraints
+>
+
+<!-- Path describe path to mode in model tree.
+     "orientation" sets orientation of splitter. "horizontal" means splitting
+     along x axis - components are from left to right. "vertical" means splitting
+     along y axis - components are from top to bottom.
+     "number" sets number of cell in given split cell. It is integer number. Number defines
+     position of given cell in array of cells. It is possible to define for example
+     20 for first cell and 40 for second cell. Later it is possible to insert third cell between
+     first and second by using 30 for third cell. It is usefull for platform to allow third party
+     modules to modify (insert) their own modes to existing layout.
+     Cells are counted from left to right in case of vertical split and
+     from top to bottom in case of horizontal split.
+     "weight" is double number from 0 to 1. It sets relative size of cell
+     in given splitter. Default value is 0.5.
+-->
+<!ELEMENT path   EMPTY >
+<!ATTLIST path
+    orientation (horizontal | vertical) #REQUIRED
+    number CDATA #REQUIRED
+    weight CDATA #IMPLIED
+>
+
+<!-- Active TopComponent.
+     "id" stores unique ID of active TopComponent
+-->
+<!ELEMENT active-tc  EMPTY >
+<!ATTLIST active-tc
+    id CDATA #IMPLIED
+    prev-id CDATA #IMPLIED
+>
+
+<!-- Element "empty-behavior" describes behavior of mode when it is empty ie. does not contain
+     any opened TopComponent.
+     Attribute "permanent" can be "true" of "false". "true" means that mode remains in window
+     system when it is empty ie. it does not contain any opened TopComponent. "false" means that
+     mode is completely destroyed when it is empty. 
+     Optional attribute, default value is "true".
+     When mode is defined in module layer it is usually permanent ie. "true" is used.
+-->
+<!ELEMENT empty-behavior   EMPTY >
+<!ATTLIST empty-behavior
+    permanent (true | false) #IMPLIED
+>
+

--- a/netbeans.apache.org/src/content/dtds/module-auto-deps-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/module-auto-deps-1_0.dtd
@@ -1,0 +1,152 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+Structure of XML files present in a NetBeans installation
+with names system/ModuleAutoDeps/*.xml (conventionally named
+according to code name base, e.g. org-netbeans-modules-foo.xml).
+
+Each file contribute some module dependency transformations
+to the system, helping backward compatibility.
+
+This file can be processed with the Generate Documentation
+context menu item in NetBeans to create an HTML summary.
+
+Public ID: "-//NetBeans//DTD Module Automatic Dependencies 1.0//EN"
+Public URL: https://netbeans.org/dtds/module-auto-deps-1_0.dtd
+
+@see "#30161"
+-->
+
+<!ENTITY % dependency 'module-dependency | package-dependency | token-dependency'>
+
+<!---
+A set of transformations to apply to all module dependencies,
+to retain backward compatibility during refactorings.
+This should be the root element of auto-deps.xml.
+Note that transformations are applied <em>in parallel</em>, so
+later transformations cannot be triggered by results from earlier
+transformations.
+-->
+<!ELEMENT transformations (transformationgroup*)>
+<!ATTLIST transformations
+          version (1.0) #REQUIRED
+>
+
+<!---
+A module to exclude from dependency transformation.
+You may give a specific module, or all modules whose code name base
+begins with some prefix.
+(For prefix: name <samp>a.b</samp> matches the module named
+<samp>a.b</samp> and all modules whose names start with <samp>a.b.</samp>.)
+-->
+<!ELEMENT exclusion EMPTY>
+<!ATTLIST exclusion
+          codenamebase CDATA #REQUIRED
+          prefix (true | false) #REQUIRED
+>
+
+<!---
+A group of transformations to apply, related to one another.
+-->
+<!ELEMENT transformationgroup (description, exclusion*, transformation+)>
+
+<!---
+Textual description of a transformation group.
+Informational only.
+-->
+<!ELEMENT description (#PCDATA)>
+
+<!---
+One dependency transformation.
+Each non-excluded module matching the trigger will
+get the specified resulting dependencies.
+-->
+<!ELEMENT transformation (trigger-dependency, implies)>
+
+<!---
+The trigger for a transformation.
+Contains an old dependency declaration.
+Cancel triggers match when the module had that dependency
+(if versioned, must be at least that new, in both major and spec)
+and when matching, delete the old dependency.
+Older triggers match when the dependency was there but on an older
+version than the one specified. (Should use a spec dep normally;
+no version at all matches only plain or spec deps on an earlier major version).
+-->
+<!ELEMENT trigger-dependency (%dependency;)>
+<!-- add as needed: (newer | negative)
+Newer triggers match when the module had that dependency
+(if it was versioned, must be at least that new, in both major and spec).
+Negative triggers match if the module did not have it.
+-->
+<!ATTLIST trigger-dependency
+          type (cancel | older) #REQUIRED
+>
+
+<!---
+Dependencies to create as a result of this transformation.
+-->
+<!ELEMENT implies (result+)>
+
+<!---
+One dependency to create as a result of this transformation.
+If the module already had a dependency on the specified object (module, ...),
+and that dependency was older than the specified one,
+then it will be <em>replaced</em> by the specified dependency.
+Otherwise a fresh dependency will be added.
+-->
+<!ELEMENT result (%dependency;)>
+
+<!---
+A dependency on a module, similar to
+<code>OpenIDE-Module-Module-Dependencies</code>.
+Never applies to implementation dependencies.
+For <code>OpenIDE-Module-IDE-Dependencies</code>,
+use codenamebase=org.openide (and major=1).
+-->
+<!ELEMENT module-dependency EMPTY>
+<!ATTLIST module-dependency
+          codenamebase CDATA #REQUIRED
+          major CDATA #IMPLIED
+          spec CDATA #IMPLIED
+>
+
+<!---
+A dependency on a package, similar to
+<code>OpenIDE-Module-Package-Dependencies</code>.
+Never applies to implementation dependencies.
+<code>name</code> here may include sample class information
+only when used in a result, not in a trigger!
+-->
+<!ELEMENT package-dependency EMPTY>
+<!ATTLIST package-dependency
+          name CDATA #REQUIRED
+          spec CDATA #IMPLIED
+>
+
+<!---
+A dependency on a token, similar to
+<code>OpenIDE-Module-Requires</code>.
+-->
+<!ELEMENT token-dependency EMPTY>
+<!ATTLIST token-dependency
+          name CDATA #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/module-status-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/module-status-1_0.dtd
@@ -1,0 +1,50 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+DTD for status of a NetBeans module.
+
+Public ID: "-//NetBeans//DTD Module Status 1.0//EN"
+Public URL: https://netbeans.org/dtds/module-status-1_0.dtd
+
+Example:
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//NetBeans//DTD Module Status 1.0//EN"
+                        "https://netbeans.org/dtds/module-status-1_0.dtd">
+<module name="org.netbeans.modules.foo">
+    <param name="autoload">false</param>
+    <param name="enabled">true</param>
+    <param name="installer">org-netbeans-modules-foo.ser</param>
+    <param name="jar">foo.jar</param>
+    <param name="origin">installation</param>
+    <param name="release">1</param>
+    <param name="reloadable">false</param>
+    <param name="specversion">1.6</param>
+</module>
+
+Such a module status would canonically be stored in the
+system file system with the name Modules/org-netbeans-modules-foo.xml.
+-->
+
+<!ELEMENT module (param)*>
+<!ATTLIST module name CDATA #REQUIRED>
+<!ELEMENT param (#PCDATA)>
+<!ATTLIST param name CDATA #REQUIRED>

--- a/netbeans.apache.org/src/content/dtds/pdf_link-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/pdf_link-1_0.dtd
@@ -1,0 +1,40 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD PDF Document Menu Link 1.0//EN
+XML file representing the desire to have a link to a PDF document.
+May be given as an absolute file, localized path within IDE home, or as a URL.
+See: org.netbeans.modules.pdf.LinkProcessor
+-->
+
+<!ELEMENT pdfLink (file | idefile | url) >
+<!ELEMENT file EMPTY>
+<!ATTLIST file
+          path CDATA #REQUIRED
+>
+<!ELEMENT idefile EMPTY>
+<!ATTLIST idefile
+          base CDATA #REQUIRED
+>
+<!ELEMENT url EMPTY>
+<!ATTLIST url
+          name CDATA #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/properties-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/properties-1_0.dtd
@@ -1,0 +1,29 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- simple properties format as a collection of name, value pairs
+-->
+
+<!ELEMENT properties (property*)>
+<!ELEMENT property EMPTY>
+<!ATTLIST property
+    name    CDATA   #REQUIRED
+    value   CDATA   #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/sessionsettings-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/sessionsettings-1_0.dtd
@@ -1,0 +1,53 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Session settings 1.0//EN
+Represents session settings
+either a default instance or a serialized bean.
+-->
+
+<!ELEMENT settings      (module?, instanceof*, (instance | serialdata)) >
+<!ATTLIST settings
+          version       (1.0) "1.0"
+>
+
+<!ELEMENT module        EMPTY >
+<!ATTLIST module
+          name          CDATA   #IMPLIED
+          spec          CDATA   #IMPLIED
+          impl          CDATA   #IMPLIED
+>
+
+<!ELEMENT instanceof    EMPTY >
+<!ATTLIST instanceof
+          class         CDATA   #REQUIRED
+>
+
+<!ELEMENT instance      EMPTY >
+<!ATTLIST instance
+          class         CDATA   #REQUIRED
+          method        CDATA   #IMPLIED
+>
+
+<!ELEMENT serialdata    (#PCDATA) >
+<!ATTLIST serialdata
+          class         CDATA   #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/tc-group2_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/tc-group2_0.dtd
@@ -1,0 +1,81 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Top Component in Group Properties 2.0//EN
+-->
+
+<!--
+    TopComponent in group reference consists of several property groups
+    for various user-interface types and optional module information.
+    Attributes:
+    "version" is versioning attribute which in fact specifies version
+    of DTD for the document. Attribute is used to perform simple versioning
+    without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT tc-group        (module?, tc-id, open-close-behavior) >
+<!ATTLIST tc-group
+    version CDATA #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of top component reference defined by module if module
+    is disabled.
+    If you want your module's top component reference to be removed
+    automatically when your module is disabled, fill this element.
+    When this element is missing, no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!--
+    Element "tc-id" contains unique identity of TopComponent.
+    "id" unique id of TopComponent. It must be defined in folder Components
+    and should be present in some mode to have any effect.
+-->
+<!ELEMENT tc-id       EMPTY >
+<!ATTLIST tc-id
+    id     CDATA        #REQUIRED
+>
+
+<!--
+    Element "open-close-behavior" contains information about behavior of
+    TopComponent in group when group is being opened or closed.
+    "open" true if component should be opened when group is being opened.
+    "close" true if component should be closed when group is being closed.
+    "was-opened" true if component is opened at moment when group is being opened.
+    It is internal flag - need not be set in default configuration. Component
+    is closed during group close when "close" is true AND "was-opened" is false.
+    Default is false.
+-->
+<!ELEMENT open-close-behavior       EMPTY >
+<!ATTLIST open-close-behavior
+    open       (true | false)   #REQUIRED
+    close      (true | false)   #REQUIRED
+    was-opened (true | false)   #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/tc-ref1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/tc-ref1_0.dtd
@@ -1,0 +1,78 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Top Component in Mode Properties 1.0//EN
+-->
+
+<!--
+    Top component reference consists of several property sets for various
+    user-interface types and optional module information. Attributes:
+ 1) "version" is optional versioning attribute, which in fact specifies version
+    of DTD for the document. Attribute is used to perform simple versioning
+    without the need to use time-consuming xml validation using this DTD.
+ 2) "id" is unique identificator of top component to which we are referring to,
+    required
+-->
+<!ELEMENT tc-ref        (module?, ui-type+) >
+<!ATTLIST tc-ref
+    version CDATA #IMPLIED
+    id CDATA #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of top component reference defined by module if module
+    is unistalled.
+    If you want your module's top component reference to be unistalled
+    automatically when your module is deinstalled, fill this element.
+    When this element is missing, no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!--
+    ui-type element, describes properties for specific type of user interface
+    1) type - id of user interface type; required. Value "any" is special value
+        which is reserved for default setting set which is used when property
+        set for specific ui-type is not found. Thus, simplest variant is to
+        define only one property set with type "any", which means that for all
+        types of user interface we have same properties.
+    2) state - opened or closed flag; if value is opened, component is showing
+       in mode, if closed, component is hidden; default value is closed
+    3) constraint - represents position of top component in frame, optional,
+       if missing, "center" value is used as default
+    5) selected - flag saying if component is selected in context of container
+        (usually tabbed pane)
+-->
+<!ELEMENT ui-type       EMPTY >
+<!ATTLIST ui-type
+    type (sdi | mdi | any) #REQUIRED
+    state (opened | closed) #IMPLIED
+    constraint (center | left | right | top | bottom) #IMPLIED
+    selected (true | false) #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/tc-ref2_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/tc-ref2_0.dtd
@@ -1,0 +1,72 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Top Component in Mode Properties 2.0//EN
+-->
+
+<!--
+    Top component reference consists of several property sets for various
+    user-interface types and optional module information.
+    Attributes:
+    "version" is versioning attribute which in fact specifies version
+    of DTD for the document. Attribute is used to perform simple versioning
+    without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT tc-ref        (module?, tc-id, state) >
+<!ATTLIST tc-ref
+    version CDATA #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of top component reference defined by module if module
+    is disabled.
+    If you want your module's top component reference to be removed
+    automatically when your module is disabled, fill this element.
+    When this element is missing, no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!--
+    Element "tc-id" contains unique identification of TopComponent.
+    "id" unique ID of TopComponent. It corresponds to name of TopComponent settings file.
+-->
+<!ELEMENT tc-id       EMPTY >
+<!ATTLIST tc-id
+    id CDATA #REQUIRED
+>
+
+<!--
+    Element "state" describes state of TopComponent in Mode.
+    "opened" is "true" when TopComponent is opened, "false" if TopComponent is closed.
+-->
+<!ELEMENT state       EMPTY >
+<!ATTLIST state
+    opened (true | false) #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/tc-ref2_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/tc-ref2_1.dtd
@@ -1,0 +1,81 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Top Component in Mode Properties 2.0//EN
+-->
+
+<!--
+    Top component reference consists of several property sets for various
+    user-interface types and optional module information.
+    Attributes:
+    "version" is versioning attribute which in fact specifies version
+    of DTD for the document. Attribute is used to perform simple versioning
+    without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT tc-ref        (module?, tc-id, state) >
+<!ATTLIST tc-ref
+    version CDATA #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of top component reference defined by module if module
+    is disabled.
+    If you want your module's top component reference to be removed
+    automatically when your module is disabled, fill this element.
+    When this element is missing, no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!--
+    Element "tc-id" contains unique identification of TopComponent.
+    "id" unique ID of TopComponent. It corresponds to name of TopComponent settings file.
+-->
+<!ELEMENT tc-id       EMPTY >
+<!ATTLIST tc-id
+    id CDATA #REQUIRED
+>
+
+<!--
+    Element "state" describes state of TopComponent in Mode.
+    "opened" is "true" when TopComponent is opened, "false" if TopComponent is closed.
+-->
+<!ELEMENT state       EMPTY >
+<!ATTLIST state
+    opened (true | false) #REQUIRED
+>
+
+<!--
+    Element "previousMode" contains identification of the mode that it resides in before this one. Useful for sliding views.
+    attribute name contanis the name of the previous mode.
+-->
+<!ELEMENT previousMode       EMPTY >
+<!ATTLIST name
+    name CDATA
+>

--- a/netbeans.apache.org/src/content/dtds/tc-ref2_2.dtd
+++ b/netbeans.apache.org/src/content/dtds/tc-ref2_2.dtd
@@ -1,0 +1,103 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Top Component in Mode Properties 2.2//EN
+-->
+
+<!--
+    Top component reference consists of several property sets for various
+    user-interface types and optional module information.
+    Attributes:
+    "version" is versioning attribute which in fact specifies version
+    of DTD for the document. Attribute is used to perform simple versioning
+    without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT tc-ref        (module?, tc-id, state, previousMode, docking-status?, slide-in-status?) >
+<!ATTLIST tc-ref
+    version CDATA #REQUIRED
+>
+
+<!-- Optional element for module information. Attribute name specifies name of
+    module which defines this xml description. Module information is used for
+    automatic removal of top component reference defined by module if module
+    is disabled.
+    If you want your module's top component reference to be removed
+    automatically when your module is disabled, fill this element.
+    When this element is missing, no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!--
+    Element "tc-id" contains unique identification of TopComponent.
+    "id" unique ID of TopComponent. It corresponds to name of TopComponent settings file.
+-->
+<!ELEMENT tc-id       EMPTY >
+<!ATTLIST tc-id
+    id CDATA #REQUIRED
+>
+
+<!--
+    Element "state" describes state of TopComponent in Mode.
+    "opened" is "true" when TopComponent is opened, "false" if TopComponent is closed.
+-->
+<!ELEMENT state       EMPTY >
+<!ATTLIST state
+    opened (true | false) #REQUIRED
+>
+
+<!--
+    Element "previousMode" contains identification of the mode that it resides in before this one. Useful for sliding views.
+    attribute name contanis the name of the previous mode.
+-->
+<!ELEMENT previousMode       EMPTY >
+<!ATTLIST name
+    name  CDATA
+    index CDATA #IMPLIED
+>
+
+
+<!--
+    Element "docking-status" describes the docking state of TopComponent.
+    "maximized-mode" is "docked" when TopComponent is docked, "slided" if TopComponent is slided to edgebar when the editor is maximized.
+    "default-mode" is "docked" when TopComponent is docked, "slided" if TopComponent is slided to edgebar in the regular, non-maximized mode.
+-->
+<!ELEMENT docking-status       EMPTY >
+<!ATTLIST docking-status
+    maximized-mode (docked | slided) #IMPLIED
+    default-mode   (docked | slided) #IMPLIED
+>
+
+<!--
+    Element "slide-in-status" describes the state of TopComponent when it is slided-in.
+    "maximized" is "true" when TopComponent covers the whole screen, "false" if TopComponent has its default or user defined size.
+-->
+<!ELEMENT slide-in-status       EMPTY >
+<!ATTLIST slide-in-status
+    maximized (true | false) #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/toolbar.dtd
+++ b/netbeans.apache.org/src/content/dtds/toolbar.dtd
@@ -1,0 +1,36 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- Document Type Declaration for toolbar configuration xml files. -->
+
+  <!-- Root element of toolbar configuration. It's a list of Rows. -->
+  <!ELEMENT Configuration (Row+)>
+
+  <!-- Toolbar configuration row. It's a list of Toolbars. -->
+  <!ELEMENT Row (Toolbar*)>
+
+  <!-- Toolbar configuration Toolbar. It contains name of toolbar,
+  it's position and switch of toolbar visibility. -->
+  <!ELEMENT Toolbar EMPTY>
+  <!ATTLIST Toolbar
+    name CDATA #REQUIRED
+    position CDATA #IMPLIED
+    visible (true | false) #IMPLIED
+  >

--- a/netbeans.apache.org/src/content/dtds/toolbar1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/toolbar1_1.dtd
@@ -1,0 +1,37 @@
+ <!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- Document Type Declaration for toolbar configuration xml files. -->
+
+  <!-- Root element of toolbar configuration. It's a list of Rows. -->
+  <!ELEMENT Configuration (Row+)>
+
+  <!-- Toolbar configuration row. It's a list of Toolbars. -->
+  <!ELEMENT Row (Toolbar*)>
+
+  <!-- Toolbar configuration Toolbar. It contains name of toolbar,
+  it's position and switch of toolbar visibility. -->
+  <!ELEMENT Toolbar EMPTY>
+  <!ATTLIST Toolbar
+    name CDATA #REQUIRED
+    visible (true | false) #IMPLIED
+    align (left | right) #IMPLIED
+    draggable (true | false) #IMPLIED
+  >

--- a/netbeans.apache.org/src/content/dtds/vcs-advanced-fssettings-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/vcs-advanced-fssettings-1_0.dtd
@@ -1,0 +1,55 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD VCS Advanced FSSettings 1.0//EN
+https://netbeans.org/dtds/vcs-advanced-fssettings-1_0.dtd
+XML representation of a VCS filesystem settings.
+Used instead of the serialization process
+-->
+
+<!ELEMENT fssettings   (configuration|fsproperties)      >
+<!ELEMENT configuration   (label|variables|commands)      >
+<!ELEMENT variables       (variable)*   >
+<!ELEMENT commands       (command)*   >
+<!ELEMENT variable       (value)   >
+<!ELEMENT command       (command|property)*   >
+<!ELEMENT property       (value)   >
+<!ELEMENT value       (#PCDATA)   >
+<!ELEMENT fsproperties   (property)*   >
+
+<!ATTLIST variable
+          name         CDATA #REQUIRED
+          basic        CDATA #IMPLIED
+          label        CDATA #IMPLIED
+          labelMnemonic CDATA #IMPLIED
+          localFile    CDATA #IMPLIED
+          localDir     CDATA #IMPLIED
+          executable   CDATA #IMPLIED
+          order        CDATA #IMPLIED
+          selector     CDATA #IMPLIED     >
+
+<!ATTLIST command
+          name         CDATA #REQUIRED
+          displayName  CDATA #IMPLIED     >
+
+<!ATTLIST property
+          name         CDATA #REQUIRED   >
+

--- a/netbeans.apache.org/src/content/dtds/vcs-configuration-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/vcs-configuration-1_0.dtd
@@ -1,0 +1,52 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD VCS Configuration 1.0//EN
+https://netbeans.org/dtds/vcs-configuration-1_0.dtd
+XML representation of a VCS commands and variables configuration profile
+-->
+
+<!ELEMENT configuration   (label|variables|commands)      >
+<!ELEMENT variables       (variable)*   >
+<!ELEMENT commands       (command)*   >
+<!ELEMENT variable       (value)   >
+<!ELEMENT command       (command|property)*   >
+<!ELEMENT property       (value)   >
+<!ELEMENT value       (#PCDATA)   >
+
+<!ATTLIST variable
+          name         CDATA #REQUIRED
+          basic        CDATA #IMPLIED
+          label        CDATA #IMPLIED
+          labelMnemonic CDATA #IMPLIED
+          localFile    CDATA #IMPLIED
+          localDir     CDATA #IMPLIED
+          executable   CDATA #IMPLIED
+          order        CDATA #IMPLIED
+          selector     CDATA #IMPLIED     >
+
+<!ATTLIST command
+          name         CDATA #REQUIRED
+          displayName  CDATA #IMPLIED     >
+
+<!ATTLIST property
+          name         CDATA #REQUIRED   >
+

--- a/netbeans.apache.org/src/content/dtds/vcs-configuration-1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/vcs-configuration-1_1.dtd
@@ -1,0 +1,88 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD VCS Configuration 1.1//EN
+https://netbeans.org/dtds/vcs-configuration-1_1.dtd
+XML representation of a VCS commands and variables configuration profile
+-->
+
+<!ELEMENT configuration    (label, resourceBundle?, os?, (condition)*, variables, commands, globalCommands?)   >
+<!ELEMENT resourceBundle   (#PCDATA)   >
+<!ELEMENT label            (#PCDATA)   >
+<!ELEMENT os               (compatible?, uncompatible?)   >
+<!ELEMENT compatible       (#PCDATA)   >
+<!ELEMENT uncompatible     (#PCDATA)   >
+<!ELEMENT condition        (var|and|or|not)*   >
+<!ELEMENT var              EMPTY   >
+<!ELEMENT and              (var|and|or|not)*   >
+<!ELEMENT or               (var|and|or|not)*   >
+<!ELEMENT not              (var)   >
+<!ELEMENT variables        (variable)*   >
+<!ELEMENT commands         (command|separator)*   >
+<!ELEMENT globalCommands   (command)*   >
+<!ELEMENT variable         (value)*   >
+<!ELEMENT command          (command|separator|property)*   >
+<!ELEMENT separator        EMPTY   >
+<!ELEMENT property         (value)*   >
+<!ELEMENT value            (#PCDATA)   >
+
+<!ATTLIST configuration
+          type             CDATA #IMPLIED   >
+          
+<!ATTLIST condition
+          var              CDATA #REQUIRED   >
+
+<!ATTLIST var
+          name             CDATA #REQUIRED
+          value            CDATA #IMPLIED
+          valueIgnoreCase  CDATA #IMPLIED
+          valueContains    CDATA #IMPLIED
+          valueContainsIgnoreCase  CDATA #IMPLIED   >
+
+<!ATTLIST variable
+          name             CDATA #REQUIRED
+          basic            CDATA #IMPLIED
+          label            CDATA #IMPLIED
+          labelMnemonic    CDATA #IMPLIED
+          localFile        CDATA #IMPLIED
+          localDir         CDATA #IMPLIED
+          executable       CDATA #IMPLIED
+          order            CDATA #IMPLIED
+          selector         CDATA #IMPLIED
+          if               CDATA #IMPLIED
+          unless           CDATA #IMPLIED   >
+
+<!ATTLIST command
+          name             CDATA #REQUIRED
+          displayName      CDATA #IMPLIED                                                                                    
+          if               CDATA #IMPLIED
+          unless           CDATA #IMPLIED     >
+
+<!ATTLIST property
+          name             CDATA #REQUIRED
+          if               CDATA #IMPLIED
+          unless           CDATA #IMPLIED    >
+
+<!ATTLIST value
+          xml:space        CDATA #IMPLIED
+          if               CDATA #IMPLIED
+          unless           CDATA #IMPLIED    >
+

--- a/netbeans.apache.org/src/content/dtds/windowmanager-properties1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/windowmanager-properties1_0.dtd
@@ -1,0 +1,71 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Window Manager Properties 1.0//EN
+-->
+
+<!-- The root element for window manager properties. Consists of subelements
+     for specific properties.
+     Atribute "version" is optional versioning attribute, which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT windowmanager (main_window?, screen?, ui-mode, active) >
+<!ATTLIST windowmanager
+    version CDATA #IMPLIED
+>
+
+<!-- Element "main-window" contains properties of main window.
+     "bounds" gives size of main window in format x, y, width, height
+-->
+<!ELEMENT main-window   EMPTY >
+<!ATTLIST main-window
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Element "screen" contains properties of screen.
+     "size" size of screen in pixels, format is width, height
+-->
+<!ELEMENT screen    EMPTY >
+<!ATTLIST screen
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Element "ui-mode" gives type of ui.
+     "ui" type of ui, possible values are "sdi","mdi"
+-->
+<!ELEMENT ui-mode    EMPTY >
+<!ATTLIST ui-mode
+    ui (sdi | mdi) #REQUIRED
+>
+
+<!-- Element "active" contains ID of active workspace.
+     "workspace" ID of active workspace
+-->
+<!ELEMENT active  EMPTY >
+<!ATTLIST active
+    workspace CDATA #IMPLIED
+>
+

--- a/netbeans.apache.org/src/content/dtds/windowmanager-properties1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/windowmanager-properties1_1.dtd
@@ -1,0 +1,102 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Window Manager Properties 1.1//EN
+-->
+
+<!-- The root element for window manager properties. Consists of subelements
+     for specific properties.
+     Atribute "version" is optional versioning attribute, which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT windowmanager (main-window?, screen?, ui-mode, active) >
+<!ATTLIST windowmanager
+    version CDATA #IMPLIED
+>
+
+<!-- Element "main-window" contains properties of main window.
+     "x" gives position of main window on screen on horizontal axis
+     left is 0, if value is "center" main window will be centered
+     horizontaly
+     "y" gives position of main window on screen on vertical axis
+     top is 0, if value is "center" main window will be centered
+     verticaly
+     Note: the "center" values are taken into account for MDI mode only!
+     "width" gives absolute width of main window
+     "height" gives absolute height of main window
+     "relative-width" gives relative width of main window, either width or
+     relative-width must be specified
+     "relative-height" gives relative width of main window, either height or
+     relative height must be specified
+     "maximize-if-width-bellow" and 
+     "maximize-if-height-bellow" are optional,
+     they specify limit on computed absolute width/height, 
+     IF min(screen.width, maximize-if-width-bellow) > main-window.width OR 
+        min(screen.height, maximize-if-height-bellow) > main-window.height THEN
+         IF screen.width > maximize-if-width-bellow AND screen.height > maximize-if-height-bellow THEN
+             set main window size to maximize-if-width-bellow, maximize-if-height-bellow
+         ELSE
+             let window maximized
+         ENDIF
+     ENDIF
+     It is simply to avoid set bounds bigger than screen size (width or height)
+-->
+<!ELEMENT main-window   EMPTY >
+<!ATTLIST main-window
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width  CDATA #IMPLIED
+    height CDATA #IMPLIED
+    relative-width  CDATA #IMPLIED
+    relative-height CDATA #IMPLIED
+    maximize-if-width-bellow  CDATA #IMPLIED
+    maximize-if-height-bellow CDATA #IMPLIED
+>
+
+<!-- Element "screen" contains properties of screen.
+     "size" size of screen in pixels, format is width, height
+-->
+<!ELEMENT screen    EMPTY >
+<!ATTLIST screen
+    width  CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Element "ui-mode" gives type of ui.
+     "ui" type of ui, possible values are "sdi","mdi"
+     This attribute should NOT be used for setting default mode. Use command line
+     switch -J-Dnetbeans.windows=sdi or -J-Dnetbeans.windows=mdi to set mode instead
+     of this attribute.
+-->
+<!ELEMENT ui-mode    EMPTY >
+<!ATTLIST ui-mode
+    ui (sdi | mdi) #REQUIRED
+>
+
+<!-- Element "active" contains ID of active workspace.
+     "workspace" ID of active workspace
+-->
+<!ELEMENT active  EMPTY >
+<!ATTLIST active
+    workspace CDATA #IMPLIED
+>
+

--- a/netbeans.apache.org/src/content/dtds/windowmanager-properties2_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/windowmanager-properties2_0.dtd
@@ -1,0 +1,293 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Window Manager Properties 2.0//EN
+-->
+
+<!-- The root element for window manager properties. Consists of subelements
+     for specific properties.
+     Attribute "version" is versioning attribute which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT windowmanager (main-window?, editor-area, screen?, active-mode?, maximized-mode?, toolbar?, tc-list?, imported-tcrefs?) >
+<!ATTLIST windowmanager
+    version CDATA #REQUIRED
+>
+
+<!-- Element "main-window" contains properties of main window.
+-->
+<!ELEMENT main-window   (joined-properties | separated-properties | 
+                         (joined-properties, separated-properties) |
+                         (separated-properties, joined-properties)) >
+<!ATTLIST main-window
+>
+
+<!-- Element "joined-properties" contains properties of main window in joined state.
+     "x" gives position of main window on screen on horizontal axis left is 0
+
+     "y" gives position of main window on screen on vertical axis top is 0
+
+     "width" gives absolute width of main window
+
+     "height" gives absolute height of main window
+
+     "relative-x" gives relative width of main window
+     Either x or relative-x or centered-horizontally true must be specified.
+
+     "relative-y" gives relative width of main window       
+     Either y or relative-y or centered-vertically must be specified.
+
+     "relative-width" gives relative width of main window
+     Either width or relative-width must be specified.
+
+     "relative-height" gives relative width of main window
+     Either height or relative-height must be specified.
+
+     "centered-horizontally" is true when main window is centered horizontally
+
+     "centered-vertically" is true when main window is centered vertically
+
+     "maximize-if-width-below" and
+
+     "maximize-if-height-below" are optional,
+     they specify limit on computed absolute width/height,
+     IF min(screen.width, maximize-if-width-below) > main-window.width OR
+        min(screen.height, maximize-if-height-below) > main-window.height THEN
+         IF screen.width > maximize-if-width-below AND screen.height > maximize-if-height-below THEN
+             set main window size to maximize-if-width-below, maximize-if-height-below
+         ELSE
+             let window maximized
+         ENDIF
+     ENDIF 
+     It is to avoid main window size bigger than screen size (width or height).
+
+     "frame-state" represents state of frame.
+     It is represented as bitwise mask - integer value.
+     See java.awt.Frame for possible values.
+     Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT joined-properties   EMPTY >
+<!ATTLIST joined-properties
+    x                     CDATA            #IMPLIED
+    y                     CDATA            #IMPLIED
+    width                 CDATA            #IMPLIED
+    height                CDATA            #IMPLIED
+    relative-x            CDATA            #IMPLIED
+    relative-y            CDATA            #IMPLIED
+    relative-width        CDATA            #IMPLIED
+    relative-height       CDATA            #IMPLIED
+    centered-horizontally (true | false)   #IMPLIED
+    centered-vertically   (true | false)   #IMPLIED
+    maximize-if-width-below  CDATA         #IMPLIED
+    maximize-if-height-below CDATA         #IMPLIED
+    frame-state           CDATA            #IMPLIED
+>
+
+<!-- Element "separated-properties" contains properties of main window in separated state.
+     "x" gives position of main window on screen on horizontal axis left is 0
+
+     "y" gives position of main window on screen on vertical axis top is 0
+
+     "width" gives absolute width of main window
+
+     "height" gives absolute height of main window
+
+     "relative-x" gives relative width of main window
+     Either x or relative-x or centered-horizontally true must be specified.
+
+     "relative-y" gives relative width of main window
+     Either y or relative-y or centered-vertically must be specified.
+
+     "relative-width" gives relative width of main window
+     Either width or relative-width must be specified.
+
+     "relative-height" gives relative width of main window
+     Either height or relative-height must be specified.
+
+     "centered-horizontally" is true when main window is centered horizontally
+
+     "centered-vertically" is true when main window is centered vertically
+
+     "frame-state" represents state of frame.
+     It is represented as bitwise mask - integer value. 
+     See java.awt.Frame for possible values.
+     Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT separated-properties   EMPTY >
+<!ATTLIST separated-properties
+    x                     CDATA            #IMPLIED
+    y                     CDATA            #IMPLIED
+    width                 CDATA            #IMPLIED
+    height                CDATA            #IMPLIED
+    relative-x            CDATA            #IMPLIED
+    relative-y            CDATA            #IMPLIED
+    relative-width        CDATA            #IMPLIED
+    relative-height       CDATA            #IMPLIED
+    centered-horizontally (true | false)   #IMPLIED
+    centered-vertically   (true | false)   #IMPLIED
+    frame-state           CDATA            #IMPLIED
+>
+
+<!-- Element "editor-area" contains bounds and constraints of editor area
+     according to state of editor area.
+     "state" sets state of editor area (desktop) joined when all windows are
+     part of main window or separated when main window, windows and EA are separate
+     into their own native windows.
+
+     "frame-state" represents state of frame.
+     It is represented as bitwise mask - integer value.
+     See java.awt.Frame for possible values.
+     Relevant for separated state of editor area when editor area resides in its own frame.
+     Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT editor-area   (constraints, (bounds | relative-bounds)?) >
+<!ATTLIST editor-area
+    state (joined | separated) #REQUIRED
+    frame-state CDATA          #IMPLIED
+>
+
+<!-- Element "bounds" contains bounds of editor area.
+     "x" gives position of editor area on screen on horizontal axis
+     left is 0.
+     "y" gives position of editor area on screen on vertical axis
+     top is 0.
+     "width" gives absolute width of editor area.
+     "height" gives absolute height of editor area.
+     Relevant only when editor area is separated from main window.
+-->
+<!ELEMENT bounds EMPTY >
+<!ATTLIST bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width  CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Relative (percentage) bounds of editor area, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle, it is relative to width of main window and height of area below
+     main window.
+     Relative bounds can be used to define starting position of separated editor area
+     in module layer (relative bounds are independent of screen size).
+     Relevant only when editor area is separated from main window.
+-->
+<!ELEMENT relative-bounds    EMPTY >
+<!ATTLIST relative-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Constraints describes path of editor area in model tree.
+     Path consists of array of values to describe path eg. [H1;V2].
+     Relevant only for editor area inside desktop
+-->
+<!ELEMENT constraints  (path*) >
+<!ATTLIST constraints
+>
+
+<!-- Path describe path to mode in model tree.
+     "orientation" sets orientation of splitter. "horizontal" means splitting
+     along x axis - components are from left to right. "vertical" means splitting
+     along y axis - components are from top to bottom.
+     "number" sets number of cell in given split cell. It is integer number. Number defines
+     position of given cell in array of cells. It is possible to define for example
+     20 for first cell and 40 for second cell. Later it is possible to insert third cell between
+     first and second by using 30 for third cell. It is usefull for platform to allow third party
+     modules to modify (insert) their own modes to existing layout.
+     Cells are counted from left to right in case of vertical split and
+     from top to bottom in case of horizontal split.
+     "weight" is double number from 0 to 1. It sets relative size of cell
+     in given splitter. Default value is 0.5.
+-->
+<!ELEMENT path   EMPTY >
+<!ATTLIST path
+    orientation (horizontal | vertical) #REQUIRED
+    number CDATA #REQUIRED
+    weight CDATA #IMPLIED
+>
+
+<!-- Element "screen" contains properties of screen.
+     "width" is width of screen in pixels
+     "height" is height of screen in pixels
+-->
+<!ELEMENT screen    EMPTY >
+<!ATTLIST screen
+    width  CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Element "active-mode" contains unique name of active mode or is empty
+     when no mode is active.
+     "name" unique name of active mode
+-->
+<!ELEMENT active-mode  EMPTY >
+<!ATTLIST active-mode
+    name CDATA #IMPLIED
+>
+
+<!-- Element "maximized-mode" contains unique name of maximized mode or is empty
+     when no mode is maximized.
+     "name" unique name of maximized mode. It is empty when no mode is maximized. -->
+<!ELEMENT maximized-mode   EMPTY >
+<!ATTLIST maximized-mode
+    name CDATA #IMPLIED
+>
+
+<!-- Toolbar attributes.
+     "configuration" name of active toolbar configuration -->
+<!ELEMENT toolbar   EMPTY >
+<!ATTLIST toolbar
+    configuration CDATA #IMPLIED
+>
+
+<!-- Element "tc-list" contains ordered list of TopComponent Ids. Used to save state of
+     RecentViewList. -->
+<!ELEMENT tc-list (tc-id*) >
+<!ATTLIST tc-list
+>
+
+<!-- Element "tc-id" contains TopComponent Id. It is part of element "tc-list".
+     "id" is unique id of TopComponent -->
+<!ELEMENT tc-id   EMPTY >
+<!ATTLIST tc-id
+    id CDATA #REQUIRED
+>
+
+<!-- Element "imported-tcrefs" contains list of imported TopComponent Ids with source
+     workspace name and source mode name. -->
+<!ELEMENT imported-tcrefs (tcref-item*) >
+<!ATTLIST imported-tcrefs
+>
+
+<!-- Element "tcref-item" contains information about imported TopComponent.
+     It is part of element "imported-tcrefs".
+     "workspace" unique name of workspace from which TopComponent was imported
+     "mode" unique name of mode from which TopComponent was imported
+     "id" is unique id of imported TopComponent -->
+<!ELEMENT tcref-item   EMPTY >
+<!ATTLIST tcref-item
+    workspace CDATA #REQUIRED
+    mode      CDATA #REQUIRED
+    id        CDATA #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/windowmanager-properties2_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/windowmanager-properties2_1.dtd
@@ -1,0 +1,295 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Window Manager Properties 2.1//EN
+-->
+
+<!-- The root element for window manager properties. Consists of subelements
+     for specific properties.
+     Attribute "version" is versioning attribute which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT windowmanager (main-window?, editor-area, screen?, active-mode?, maximized-mode?, toolbar?, tc-list?, imported-tcrefs?) >
+<!ATTLIST windowmanager
+    version CDATA #REQUIRED
+>
+
+<!-- Element "main-window" contains properties of main window.
+-->
+<!ELEMENT main-window   (joined-properties | separated-properties | 
+                         (joined-properties, separated-properties) |
+                         (separated-properties, joined-properties)) >
+<!ATTLIST main-window
+>
+
+<!-- Element "joined-properties" contains properties of main window in joined state.
+     "x" gives position of main window on screen on horizontal axis left is 0
+
+     "y" gives position of main window on screen on vertical axis top is 0
+
+     "width" gives absolute width of main window
+
+     "height" gives absolute height of main window
+
+     "relative-x" gives relative width of main window
+     Either x or relative-x or centered-horizontally true must be specified.
+
+     "relative-y" gives relative width of main window       
+     Either y or relative-y or centered-vertically must be specified.
+
+     "relative-width" gives relative width of main window
+     Either width or relative-width must be specified.
+
+     "relative-height" gives relative width of main window
+     Either height or relative-height must be specified.
+
+     "centered-horizontally" is true when main window is centered horizontally
+
+     "centered-vertically" is true when main window is centered vertically
+
+     "maximize-if-width-below" and
+
+     "maximize-if-height-below" are optional,
+     they specify limit on computed absolute width/height,
+     IF min(screen.width, maximize-if-width-below) > main-window.width OR
+        min(screen.height, maximize-if-height-below) > main-window.height THEN
+         IF screen.width > maximize-if-width-below AND screen.height > maximize-if-height-below THEN
+             set main window size to maximize-if-width-below, maximize-if-height-below
+         ELSE
+             let window maximized
+         ENDIF
+     ENDIF 
+     It is to avoid main window size bigger than screen size (width or height).
+
+     "frame-state" represents state of frame.
+     It is represented as bitwise mask - integer value.
+     See java.awt.Frame for possible values.
+     Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT joined-properties   EMPTY >
+<!ATTLIST joined-properties
+    x                     CDATA            #IMPLIED
+    y                     CDATA            #IMPLIED
+    width                 CDATA            #IMPLIED
+    height                CDATA            #IMPLIED
+    relative-x            CDATA            #IMPLIED
+    relative-y            CDATA            #IMPLIED
+    relative-width        CDATA            #IMPLIED
+    relative-height       CDATA            #IMPLIED
+    centered-horizontally (true | false)   #IMPLIED
+    centered-vertically   (true | false)   #IMPLIED
+    maximize-if-width-below  CDATA         #IMPLIED
+    maximize-if-height-below CDATA         #IMPLIED
+    frame-state           CDATA            #IMPLIED
+>
+
+<!-- Element "separated-properties" contains properties of main window in separated state.
+     "x" gives position of main window on screen on horizontal axis left is 0
+
+     "y" gives position of main window on screen on vertical axis top is 0
+
+     "width" gives absolute width of main window
+
+     "height" gives absolute height of main window
+
+     "relative-x" gives relative width of main window
+     Either x or relative-x or centered-horizontally true must be specified.
+
+     "relative-y" gives relative width of main window
+     Either y or relative-y or centered-vertically must be specified.
+
+     "relative-width" gives relative width of main window
+     Either width or relative-width must be specified.
+
+     "relative-height" gives relative width of main window
+     Either height or relative-height must be specified.
+
+     "centered-horizontally" is true when main window is centered horizontally
+
+     "centered-vertically" is true when main window is centered vertically
+
+     "frame-state" represents state of frame.
+     It is represented as bitwise mask - integer value. 
+     See java.awt.Frame for possible values.
+     Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT separated-properties   EMPTY >
+<!ATTLIST separated-properties
+    x                     CDATA            #IMPLIED
+    y                     CDATA            #IMPLIED
+    width                 CDATA            #IMPLIED
+    height                CDATA            #IMPLIED
+    relative-x            CDATA            #IMPLIED
+    relative-y            CDATA            #IMPLIED
+    relative-width        CDATA            #IMPLIED
+    relative-height       CDATA            #IMPLIED
+    centered-horizontally (true | false)   #IMPLIED
+    centered-vertically   (true | false)   #IMPLIED
+    frame-state           CDATA            #IMPLIED
+>
+
+<!-- Element "editor-area" contains bounds and constraints of editor area
+     according to state of editor area.
+     "state" sets state of editor area (desktop) joined when all windows are
+     part of main window or separated when main window, windows and EA are separate
+     into their own native windows.
+
+     "frame-state" represents state of frame.
+     It is represented as bitwise mask - integer value.
+     See java.awt.Frame for possible values.
+     Relevant for separated state of editor area when editor area resides in its own frame.
+     Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT editor-area   (constraints, (bounds | relative-bounds)?) >
+<!ATTLIST editor-area
+    state (joined | separated) #REQUIRED
+    frame-state CDATA          #IMPLIED
+>
+
+<!-- Element "bounds" contains bounds of editor area.
+     "x" gives position of editor area on screen on horizontal axis
+     left is 0.
+     "y" gives position of editor area on screen on vertical axis
+     top is 0.
+     "width" gives absolute width of editor area.
+     "height" gives absolute height of editor area.
+     Relevant only when editor area is separated from main window.
+-->
+<!ELEMENT bounds EMPTY >
+<!ATTLIST bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width  CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Relative (percentage) bounds of editor area, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle, it is relative to width of main window and height of area below
+     main window.
+     Relative bounds can be used to define starting position of separated editor area
+     in module layer (relative bounds are independent of screen size).
+     Relevant only when editor area is separated from main window.
+-->
+<!ELEMENT relative-bounds    EMPTY >
+<!ATTLIST relative-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Constraints describes path of editor area in model tree.
+     Path consists of array of values to describe path eg. [H1;V2].
+     Relevant only for editor area inside desktop
+-->
+<!ELEMENT constraints  (path*) >
+<!ATTLIST constraints
+>
+
+<!-- Path describe path to mode in model tree.
+     "orientation" sets orientation of splitter. "horizontal" means splitting
+     along x axis - components are from left to right. "vertical" means splitting
+     along y axis - components are from top to bottom.
+     "number" sets number of cell in given split cell. It is integer number. Number defines
+     position of given cell in array of cells. It is possible to define for example
+     20 for first cell and 40 for second cell. Later it is possible to insert third cell between
+     first and second by using 30 for third cell. It is usefull for platform to allow third party
+     modules to modify (insert) their own modes to existing layout.
+     Cells are counted from left to right in case of vertical split and
+     from top to bottom in case of horizontal split.
+     "weight" is double number from 0 to 1. It sets relative size of cell
+     in given splitter. Default value is 0.5.
+-->
+<!ELEMENT path   EMPTY >
+<!ATTLIST path
+    orientation (horizontal | vertical) #REQUIRED
+    number CDATA #REQUIRED
+    weight CDATA #IMPLIED
+>
+
+<!-- Element "screen" contains properties of screen.
+     "width" is width of screen in pixels
+     "height" is height of screen in pixels
+-->
+<!ELEMENT screen    EMPTY >
+<!ATTLIST screen
+    width  CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Element "active-mode" contains unique name of active mode or is empty
+     when no mode is active.
+     "name" unique name of active mode
+-->
+<!ELEMENT active-mode  EMPTY >
+<!ATTLIST active-mode
+    name CDATA #IMPLIED
+>
+
+<!-- Element "maximized-mode" contains unique name of maximized mode or is empty
+     when no mode is maximized.
+     "name" unique name of maximized mode. It is empty when no mode is maximized. -->
+<!ELEMENT maximized-mode   EMPTY >
+<!ATTLIST maximized-mode
+    name CDATA #IMPLIED
+>
+
+<!-- Toolbar attributes.
+     "configuration" name of active toolbar configuration 
+     "preferred-icon-size" preferred size of icons used in toolbar buttons -->
+<!ELEMENT toolbar   EMPTY >
+<!ATTLIST toolbar
+    configuration       CDATA     #IMPLIED
+    preferred-icon-size (16 | 24) #IMPLIED
+>
+
+<!-- Element "tc-list" contains ordered list of TopComponent Ids. Used to save state of
+     RecentViewList. -->
+<!ELEMENT tc-list (tc-id*) >
+<!ATTLIST tc-list
+>
+
+<!-- Element "tc-id" contains TopComponent Id. It is part of element "tc-list".
+     "id" is unique id of TopComponent -->
+<!ELEMENT tc-id   EMPTY >
+<!ATTLIST tc-id
+    id CDATA #REQUIRED
+>
+
+<!-- Element "imported-tcrefs" contains list of imported TopComponent Ids with source
+     workspace name and source mode name. -->
+<!ELEMENT imported-tcrefs (tcref-item*) >
+<!ATTLIST imported-tcrefs
+>
+
+<!-- Element "tcref-item" contains information about imported TopComponent.
+     It is part of element "imported-tcrefs".
+     "workspace" unique name of workspace from which TopComponent was imported
+     "mode" unique name of mode from which TopComponent was imported
+     "id" is unique id of imported TopComponent -->
+<!ELEMENT tcref-item   EMPTY >
+<!ATTLIST tcref-item
+    workspace CDATA #REQUIRED
+    mode      CDATA #REQUIRED
+    id        CDATA #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/windowmanager-properties2_2.dtd
+++ b/netbeans.apache.org/src/content/dtds/windowmanager-properties2_2.dtd
@@ -1,0 +1,297 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Window Manager Properties 2.2//EN
+-->
+
+<!-- The root element for window manager properties. Consists of subelements
+     for specific properties.
+     Attribute "version" is versioning attribute which in fact specifies
+     version of this DTD. Attribute is used to perform simple versioning
+     without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT windowmanager (main-window?, editor-area, screen?, active-mode?, maximized-mode?, toolbar?, tc-list?, imported-tcrefs?) >
+<!ATTLIST windowmanager
+    version CDATA #REQUIRED
+>
+
+<!-- Element "main-window" contains properties of main window.
+-->
+<!ELEMENT main-window   (joined-properties | separated-properties | 
+                         (joined-properties, separated-properties) |
+                         (separated-properties, joined-properties)) >
+<!ATTLIST main-window
+>
+
+<!-- Element "joined-properties" contains properties of main window in joined state.
+     "x" gives position of main window on screen on horizontal axis left is 0
+
+     "y" gives position of main window on screen on vertical axis top is 0
+
+     "width" gives absolute width of main window
+
+     "height" gives absolute height of main window
+
+     "relative-x" gives relative width of main window
+     Either x or relative-x or centered-horizontally true must be specified.
+
+     "relative-y" gives relative width of main window       
+     Either y or relative-y or centered-vertically must be specified.
+
+     "relative-width" gives relative width of main window
+     Either width or relative-width must be specified.
+
+     "relative-height" gives relative width of main window
+     Either height or relative-height must be specified.
+
+     "centered-horizontally" is true when main window is centered horizontally
+
+     "centered-vertically" is true when main window is centered vertically
+
+     "maximize-if-width-below" and
+
+     "maximize-if-height-below" are optional,
+     they specify limit on computed absolute width/height,
+     IF min(screen.width, maximize-if-width-below) > main-window.width OR
+        min(screen.height, maximize-if-height-below) > main-window.height THEN
+         IF screen.width > maximize-if-width-below AND screen.height > maximize-if-height-below THEN
+             set main window size to maximize-if-width-below, maximize-if-height-below
+         ELSE
+             let window maximized
+         ENDIF
+     ENDIF 
+     It is to avoid main window size bigger than screen size (width or height).
+
+     "frame-state" represents state of frame.
+     It is represented as bitwise mask - integer value.
+     See java.awt.Frame for possible values.
+     Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT joined-properties   EMPTY >
+<!ATTLIST joined-properties
+    x                     CDATA            #IMPLIED
+    y                     CDATA            #IMPLIED
+    width                 CDATA            #IMPLIED
+    height                CDATA            #IMPLIED
+    relative-x            CDATA            #IMPLIED
+    relative-y            CDATA            #IMPLIED
+    relative-width        CDATA            #IMPLIED
+    relative-height       CDATA            #IMPLIED
+    centered-horizontally (true | false)   #IMPLIED
+    centered-vertically   (true | false)   #IMPLIED
+    maximize-if-width-below  CDATA         #IMPLIED
+    maximize-if-height-below CDATA         #IMPLIED
+    frame-state           CDATA            #IMPLIED
+>
+
+<!-- Element "separated-properties" contains properties of main window in separated state.
+     "x" gives position of main window on screen on horizontal axis left is 0
+
+     "y" gives position of main window on screen on vertical axis top is 0
+
+     "width" gives absolute width of main window
+
+     "height" gives absolute height of main window
+
+     "relative-x" gives relative width of main window
+     Either x or relative-x or centered-horizontally true must be specified.
+
+     "relative-y" gives relative width of main window
+     Either y or relative-y or centered-vertically must be specified.
+
+     "relative-width" gives relative width of main window
+     Either width or relative-width must be specified.
+
+     "relative-height" gives relative width of main window
+     Either height or relative-height must be specified.
+
+     "centered-horizontally" is true when main window is centered horizontally
+
+     "centered-vertically" is true when main window is centered vertically
+
+     "frame-state" represents state of frame.
+     It is represented as bitwise mask - integer value. 
+     See java.awt.Frame for possible values.
+     Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT separated-properties   EMPTY >
+<!ATTLIST separated-properties
+    x                     CDATA            #IMPLIED
+    y                     CDATA            #IMPLIED
+    width                 CDATA            #IMPLIED
+    height                CDATA            #IMPLIED
+    relative-x            CDATA            #IMPLIED
+    relative-y            CDATA            #IMPLIED
+    relative-width        CDATA            #IMPLIED
+    relative-height       CDATA            #IMPLIED
+    centered-horizontally (true | false)   #IMPLIED
+    centered-vertically   (true | false)   #IMPLIED
+    frame-state           CDATA            #IMPLIED
+>
+
+<!-- Element "editor-area" contains bounds and constraints of editor area
+     according to state of editor area.
+     "state" sets state of editor area (desktop) joined when all windows are
+     part of main window or separated when main window, windows and EA are separate
+     into their own native windows.
+
+     "frame-state" represents state of frame.
+     It is represented as bitwise mask - integer value.
+     See java.awt.Frame for possible values.
+     Relevant for separated state of editor area when editor area resides in its own frame.
+     Default value is Frame.NORMAL (0).
+-->
+<!ELEMENT editor-area   (constraints, (bounds | relative-bounds)?) >
+<!ATTLIST editor-area
+    state (joined | separated) #REQUIRED
+    frame-state CDATA          #IMPLIED
+>
+
+<!-- Element "bounds" contains bounds of editor area.
+     "x" gives position of editor area on screen on horizontal axis
+     left is 0.
+     "y" gives position of editor area on screen on vertical axis
+     top is 0.
+     "width" gives absolute width of editor area.
+     "height" gives absolute height of editor area.
+     Relevant only when editor area is separated from main window.
+-->
+<!ELEMENT bounds EMPTY >
+<!ATTLIST bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width  CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Relative (percentage) bounds of editor area, stored in attributes
+     x, y, width, height, where x, y is location of left top point of bounds
+     rectangle, it is relative to width of main window and height of area below
+     main window.
+     Relative bounds can be used to define starting position of separated editor area
+     in module layer (relative bounds are independent of screen size).
+     Relevant only when editor area is separated from main window.
+-->
+<!ELEMENT relative-bounds    EMPTY >
+<!ATTLIST relative-bounds
+    x CDATA #REQUIRED
+    y CDATA #REQUIRED
+    width CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Constraints describes path of editor area in model tree.
+     Path consists of array of values to describe path eg. [H1;V2].
+     Relevant only for editor area inside desktop
+-->
+<!ELEMENT constraints  (path*) >
+<!ATTLIST constraints
+>
+
+<!-- Path describe path to mode in model tree.
+     "orientation" sets orientation of splitter. "horizontal" means splitting
+     along x axis - components are from left to right. "vertical" means splitting
+     along y axis - components are from top to bottom.
+     "number" sets number of cell in given split cell. It is integer number. Number defines
+     position of given cell in array of cells. It is possible to define for example
+     20 for first cell and 40 for second cell. Later it is possible to insert third cell between
+     first and second by using 30 for third cell. It is usefull for platform to allow third party
+     modules to modify (insert) their own modes to existing layout.
+     Cells are counted from left to right in case of vertical split and
+     from top to bottom in case of horizontal split.
+     "weight" is double number from 0 to 1. It sets relative size of cell
+     in given splitter. Default value is 0.5.
+-->
+<!ELEMENT path   EMPTY >
+<!ATTLIST path
+    orientation (horizontal | vertical) #REQUIRED
+    number CDATA #REQUIRED
+    weight CDATA #IMPLIED
+>
+
+<!-- Element "screen" contains properties of screen.
+     "width" is width of screen in pixels
+     "height" is height of screen in pixels
+-->
+<!ELEMENT screen    EMPTY >
+<!ATTLIST screen
+    width  CDATA #REQUIRED
+    height CDATA #REQUIRED
+>
+
+<!-- Element "active-mode" contains unique name of active mode or is empty
+     when no mode is active.
+     "name" unique name of active mode
+-->
+<!ELEMENT active-mode  EMPTY >
+<!ATTLIST active-mode
+    name CDATA #IMPLIED
+>
+
+<!-- Element "maximized-mode" contains unique name of maximized mode or is empty
+     when no mode is maximized.
+     "editor" unique name of editor maximized mode. It is empty when the editor mode is not maximized.
+     "view" unique name of view maximized mode. It is empty when no view mode is maximized. -->
+<!ELEMENT maximized-mode   EMPTY >
+<!ATTLIST maximized-mode
+    editor CDATA #IMPLIED
+    view CDATA #IMPLIED
+>
+
+<!-- Toolbar attributes.
+     "configuration" name of active toolbar configuration 
+     "preferred-icon-size" preferred size of icons used in toolbar buttons -->
+<!ELEMENT toolbar   EMPTY >
+<!ATTLIST toolbar
+    configuration       CDATA     #IMPLIED
+    preferred-icon-size (16 | 24) #IMPLIED
+>
+
+<!-- Element "tc-list" contains ordered list of TopComponent Ids. Used to save state of
+     RecentViewList. -->
+<!ELEMENT tc-list (tc-id*) >
+<!ATTLIST tc-list
+>
+
+<!-- Element "tc-id" contains TopComponent Id. It is part of element "tc-list".
+     "id" is unique id of TopComponent -->
+<!ELEMENT tc-id   EMPTY >
+<!ATTLIST tc-id
+    id CDATA #REQUIRED
+>
+
+<!-- Element "imported-tcrefs" contains list of imported TopComponent Ids with source
+     workspace name and source mode name. -->
+<!ELEMENT imported-tcrefs (tcref-item*) >
+<!ATTLIST imported-tcrefs
+>
+
+<!-- Element "tcref-item" contains information about imported TopComponent.
+     It is part of element "imported-tcrefs".
+     "workspace" unique name of workspace from which TopComponent was imported
+     "mode" unique name of mode from which TopComponent was imported
+     "id" is unique id of imported TopComponent -->
+<!ELEMENT tcref-item   EMPTY >
+<!ATTLIST tcref-item
+    workspace CDATA #REQUIRED
+    mode      CDATA #REQUIRED
+    id        CDATA #REQUIRED
+>

--- a/netbeans.apache.org/src/content/dtds/workspace-properties1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/workspace-properties1_0.dtd
@@ -1,0 +1,144 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Workspace Properties 1.0//EN
+-->
+
+<!-- The root element for workspace properties. Consists of name, optional
+    module information and workspace property sets for various types of user
+    interface.
+    Atribute "version" is optional versioning attribute, which in fact specifies
+    version of this DTD. Attribute is used to perform simple versioning
+    without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT workspace (name, description?, module?, ui-type+) >
+<!ATTLIST workspace
+    version CDATA #IMPLIED
+>
+
+<!-- Element for user interface type, holds property set for workspace for
+    specific user interface type. UI type is identified by its only attribute "type",
+    Value "any" is special value which is reserved for default setting set which
+    is used when property set for specific ui-type is not found. Thus, simplest variant is to
+    define only one property set with type "any", which means that for all
+    types of user interface workspace will have same properties. -->
+<!ELEMENT ui-type (cascade?, active?, order?, mode?, toolbar?) >
+<!ATTLIST ui-type
+    type (sdi | mdi | any) #REQUIRED
+>
+
+<!-- Optional element for module information. Module information is used for
+    automatic removal of workspace defined by module if module is unistalled.
+    If you want your module's workspace to be unistalled automatically when
+    your module is deinstalled, fill this element. When this element is missing,
+    no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!-- Element name has four attributes:
+    1) "unique" represents UID of the workspace
+    2) "display" represents optional display name of the workspace.
+       If display name is not specified, unique name is used as display name
+       too. If "from-bundle" flag is enabled, this attribute must contain
+       bundle key where to find localized display name.
+    3) "from-bundle" flag to control if display name is taken from bundle or not
+    4) "bundle" identifies bundle from which localized display name will be read.
+       Format is the same like for fully qualified classes. For example, 
+       localization bundle named "Bundle" in package "my.package" can be pointed
+       to by value "my.package.Bundle".
+       Attributes "bundle" and "display" together give fully qualified bundle
+       pointer. This attribute is optional, has no meaning if "from-bundle" is false
+-->
+<!ELEMENT name      EMPTY >
+<!ATTLIST name
+    unique CDATA #REQUIRED
+    display CDATA #IMPLIED
+    from-bundle (true | false) #IMPLIED
+    bundle CDATA #IMPLIED
+>
+
+<!-- Optional element description has two attributes
+    1) "display" represents bundle key where to find localized 
+        workspace description. (example value: "CTL_MyWorkspaceDescription")
+    2) "bundle" identifies bundle from which localized description will be read.
+       Format is the same like for fully qualified classes. For example, 
+       localization bundle named "Bundle" in package "my.package" can be pointed
+       to by value "my.package.Bundle".
+       Attributes "bundle" and "display" together give fully qualified bundle
+       pointer.
+-->
+<!ELEMENT description EMPTY >
+<!ATTLIST description
+    display CDATA #REQUIRED
+    bundle CDATA #REQUIRED
+>
+
+<!-- Cascading value for placing new frames. 
+     "origin-x" x coordinate where cascading starts
+     "origin-y" y coordinate where cascading starts
+     "step-x" x step added to coordinates for new frame
+     "step-y" y step added to coordinates for new frame
+     "count" number of steps already performed
+     "current-x" x coordinate of current frame
+     "current-y" y coordinate of current frame
+-->
+<!ELEMENT cascade    EMPTY >
+<!ATTLIST cascade
+    origin-x CDATA #REQUIRED
+    origin-y CDATA #REQUIRED
+    step-x CDATA #REQUIRED
+    step-y CDATA #REQUIRED
+    count CDATA #REQUIRED
+    current-x CDATA #REQUIRED
+    current-y CDATA #REQUIRED
+>
+
+<!-- Active mode (frame) in workspace.
+     "mode" ID of active mode in workspace
+-->
+<!ELEMENT active    EMPTY >
+<!ATTLIST active
+    mode CDATA #REQUIRED
+>
+
+<!-- z-order of frames in workspace.
+     "z-order" gives Z-order of frames in workspace given by comma separated list of mode's IDs
+-->
+<!ELEMENT mode   EMPTY >
+<!ATTLIST mode
+    z-order CDATA #REQUIRED
+>
+
+<!-- Toolbar attributes.
+     "configuration" name of toolbar configuration -->
+<!ELEMENT toolbar   EMPTY >
+<!ATTLIST toolbar
+    configuration CDATA #IMPLIED
+>
+

--- a/netbeans.apache.org/src/content/dtds/workspace-properties1_1.dtd
+++ b/netbeans.apache.org/src/content/dtds/workspace-properties1_1.dtd
@@ -1,0 +1,150 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD Workspace Properties 1.1//EN
+-->
+
+<!-- The root element for workspace properties. Consists of name, optional
+    module information and workspace property sets for various types of user
+    interface.
+    Atribute "version" is optional versioning attribute, which in fact specifies
+    version of this DTD. Attribute is used to perform simple versioning
+    without the need to use time-consuming xml validation using this DTD.
+-->
+<!ELEMENT workspace (name, description?, module?, ui-type+) >
+<!ATTLIST workspace
+    version CDATA #IMPLIED
+>
+
+<!-- Element for user interface type, holds property set for workspace for
+    specific user interface type. UI type is identified by its only attribute "type",
+    Value "any" is special value which is reserved for default setting set which
+    is used when property set for specific ui-type is not found. Thus, simplest variant is to
+    define only one property set with type "any", which means that for all
+    types of user interface workspace will have same properties. -->
+<!ELEMENT ui-type (cascade?, active?, order?, mode?, toolbar?, desktop?) >
+<!ATTLIST ui-type
+    type (sdi | mdi | any) #REQUIRED
+>
+
+<!-- Optional element for module information. Module information is used for
+    automatic removal of workspace defined by module if module is unistalled.
+    If you want your module's workspace to be unistalled automatically when
+    your module is deinstalled, fill this element. When this element is missing,
+    no automatic removal will be done.
+ 1) "name" code name of the module, can be either base code name or full code
+    name with slash and release number. Examples for core module are: 
+    "org.netbeans.core" or "org.netbeans.core/1"
+ 2) "spec" is specification version of the module which defines this xml description.
+-->
+<!ELEMENT module EMPTY >
+<!ATTLIST module
+    name CDATA #REQUIRED
+    spec CDATA #IMPLIED
+>
+
+<!-- Element name has four attributes:
+    1) "unique" represents UID of the workspace
+    2) "display" represents optional display name of the workspace.
+       If display name is not specified, unique name is used as display name
+       too. If "from-bundle" flag is enabled, this attribute must contain
+       bundle key where to find localized display name.
+    3) "from-bundle" flag to control if display name is taken from bundle or not
+    4) "bundle" identifies bundle from which localized display name will be read.
+       Format is the same like for fully qualified classes. For example, 
+       localization bundle named "Bundle" in package "my.package" can be pointed
+       to by value "my.package.Bundle".
+       Attributes "bundle" and "display" together give fully qualified bundle
+       pointer. This attribute is optional, has no meaning if "from-bundle" is false
+-->
+<!ELEMENT name      EMPTY >
+<!ATTLIST name
+    unique CDATA #REQUIRED
+    display CDATA #IMPLIED
+    from-bundle (true | false) #IMPLIED
+    bundle CDATA #IMPLIED
+>
+
+<!-- Optional element description has two attributes
+    1) "display" represents bundle key where to find localized 
+        workspace description. (example value: "CTL_MyWorkspaceDescription")
+    2) "bundle" identifies bundle from which localized description will be read.
+       Format is the same like for fully qualified classes. For example, 
+       localization bundle named "Bundle" in package "my.package" can be pointed
+       to by value "my.package.Bundle".
+       Attributes "bundle" and "display" together give fully qualified bundle
+       pointer.
+-->
+<!ELEMENT description EMPTY >
+<!ATTLIST description
+    display CDATA #REQUIRED
+    bundle CDATA #REQUIRED
+>
+
+<!-- Cascading value for placing new frames. 
+     "origin-x" x coordinate where cascading starts
+     "origin-y" y coordinate where cascading starts
+     "step-x" x step added to coordinates for new frame
+     "step-y" y step added to coordinates for new frame
+     "count" number of steps already performed
+     "current-x" x coordinate of current frame
+     "current-y" y coordinate of current frame
+-->
+<!ELEMENT cascade    EMPTY >
+<!ATTLIST cascade
+    origin-x CDATA #REQUIRED
+    origin-y CDATA #REQUIRED
+    step-x CDATA #REQUIRED
+    step-y CDATA #REQUIRED
+    count CDATA #REQUIRED
+    current-x CDATA #REQUIRED
+    current-y CDATA #REQUIRED
+>
+
+<!-- Active mode (frame) in workspace.
+     "mode" ID of active mode in workspace
+-->
+<!ELEMENT active    EMPTY >
+<!ATTLIST active
+    mode CDATA #REQUIRED
+>
+
+<!-- z-order of frames in workspace.
+     "z-order" gives Z-order of frames in workspace given by comma separated list of mode's IDs
+-->
+<!ELEMENT mode   EMPTY >
+<!ATTLIST mode
+    z-order CDATA #REQUIRED
+>
+
+<!-- Toolbar attributes.
+     "configuration" name of toolbar configuration -->
+<!ELEMENT toolbar   EMPTY >
+<!ATTLIST toolbar
+    configuration CDATA #IMPLIED
+>
+
+<!-- Inner desktop attributes. Valid only for mdi ui type.
+     "maximized" true if inner desktop contains maximized frames -->
+<!ELEMENT desktop   EMPTY >
+<!ATTLIST maximized
+    maximized CDATA #IMPLIED
+>

--- a/netbeans.apache.org/src/content/dtds/xml-beans-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/xml-beans-1_0.dtd
@@ -1,0 +1,131 @@
+<?xml encoding="UTF-8" ?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<!ELEMENT java (
+    object   | 
+    void     | 
+    string   |  
+    class    | 
+    null     | 
+    array    | 
+    boolean  | 
+    byte     | 
+    char     | 
+    short    | 
+    int      | 
+    long     | 
+    float    |  
+    double
+)*>
+<!ATTLIST java 
+    version  CDATA  #IMPLIED
+    class    CDATA  #IMPLIED
+>
+
+<!ELEMENT boolean (#PCDATA)>
+<!ELEMENT byte    (#PCDATA)>
+<!ELEMENT char    (#PCDATA)>
+<!ELEMENT short   (#PCDATA)>
+<!ELEMENT int     (#PCDATA)>
+<!ELEMENT long    (#PCDATA)>
+<!ELEMENT float   (#PCDATA)>
+<!ELEMENT double  (#PCDATA)>
+
+<!ELEMENT string  (#PCDATA)>
+<!ELEMENT class   (#PCDATA)>
+<!ELEMENT null    (#PCDATA)>
+
+<!ELEMENT object (
+    object   | 
+    void     | 
+    string   |  
+    class    | 
+    null     | 
+    array    | 
+    boolean  | 
+    byte     | 
+    char     | 
+    short    | 
+    int      | 
+    long     | 
+    float    |  
+    double
+)*>
+<!ATTLIST object 
+    id       ID     #IMPLIED
+    idref    IDREF  #IMPLIED
+    class    CDATA  #IMPLIED
+    field    CDATA  #IMPLIED
+    method   CDATA  #IMPLIED
+    property CDATA  #IMPLIED
+    index    CDATA  #IMPLIED
+>
+
+<!ELEMENT array (
+    object   | 
+    void     | 
+    string   |  
+    class    | 
+    null     | 
+    array    | 
+    boolean  | 
+    byte     | 
+    char     | 
+    short    | 
+    int      | 
+    long     | 
+    float    |  
+    double
+)*>
+<!ATTLIST array 
+    id       ID     #IMPLIED
+    class    CDATA  #IMPLIED
+    length   CDATA  #IMPLIED
+>
+
+<!ELEMENT void (
+    object   | 
+    void     | 
+    string   |  
+    class    | 
+    null     | 
+    array    | 
+    boolean  | 
+    byte     | 
+    char     | 
+    short    | 
+    int      | 
+    long     | 
+    float    |  
+    double
+)*>
+<!ATTLIST void 
+    id       ID     #IMPLIED
+    class    CDATA  #IMPLIED
+    method   CDATA  #IMPLIED
+    property CDATA  #IMPLIED
+    index    CDATA  #IMPLIED
+>
+
+
+
+

--- a/netbeans.apache.org/src/content/dtds/xtest-cfg-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/xtest-cfg-1_0.dtd
@@ -1,0 +1,80 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD XTest cfg 1.0//EN
+-->
+
+<!-- DTD for xtest cfg files -->
+
+<!ELEMENT mconfig (testbag+,executor+,compiler*)>
+<!ATTLIST mconfig
+    name CDATA #REQUIRED
+>
+
+<!ELEMENT testbag (testproperty*,testset+)>
+<!ATTLIST testbag
+    name             CDATA #REQUIRED
+    testattribs	     CDATA #REQUIRED
+    executor         CDATA #IMPLIED
+    compiler         CDATA #IMPLIED
+    resultsprocessor CDATA #IMPLIED
+>
+
+<!ELEMENT testproperty EMPTY>
+<!ATTLIST testproperty
+    name  CDATA #REQUIRED
+    value CDATA #REQUIRED
+>
+
+<!ELEMENT testset (patternset*)>
+<!ATTLIST testset
+    dir CDATA #REQUIRED
+>
+
+<!ELEMENT patternset ((include|exclude)*)>
+<!ELEMENT include EMPTY>
+<!ATTLIST include 
+    name CDATA #REQUIRED
+    expectedFail CDATA #IMPLIED
+>
+
+<!ELEMENT exclude EMPTY>
+<!ATTLIST exclude 
+    name CDATA #REQUIRED
+>
+
+<!ELEMENT executor EMPTY>
+<!ATTLIST executor
+    name    CDATA #REQUIRED
+    antfile CDATA #IMPLIED
+    target  CDATA #IMPLIED
+    dir     CDATA #IMPLIED
+    default (true|false|yes|no|0|1) "false"
+>
+
+<!ELEMENT compiler EMPTY>
+<!ATTLIST compiler
+    name    CDATA #REQUIRED
+    antfile CDATA #IMPLIED
+    target  CDATA #IMPLIED
+    dir     CDATA #IMPLIED
+    default (true|false|yes|no|0|1) "false"
+>

--- a/netbeans.apache.org/src/content/dtds/xtest-master-config-1_0.dtd
+++ b/netbeans.apache.org/src/content/dtds/xtest-master-config-1_0.dtd
@@ -1,0 +1,80 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+-//NetBeans//DTD XTest Master Config 1.0//EN
+-->
+
+<!ELEMENT testconfig (setup|config)*>
+
+<!ELEMENT config (module|testtype|property)*>
+<!ATTLIST config
+    name CDATA #REQUIRED
+    setup CDATA #IMPLIED
+    defaultAttributes CDATA #IMPLIED
+    defaultTestypes CDATA #IMPLIED
+  >
+  
+<!ELEMENT module (property)*>
+<!ATTLIST module
+    name CDATA #REQUIRED
+    testtypes CDATA #IMPLIED
+    attributes CDATA #IMPLIED
+    setup CDATA #IMPLIED
+  >
+  
+<!ELEMENT testtype (property)*>
+<!ATTLIST testtype
+    name CDATA #REQUIRED
+    modules CDATA #IMPLIED
+    attributes CDATA #IMPLIED
+    setup CDATA #IMPLIED
+  >
+
+<!ELEMENT property EMPTY>
+<!ATTLIST property
+    name CDATA #IMPLIED
+    value CDATA #IMPLIED
+    file CDATA #IMPLIED
+  >
+  
+<!ELEMENT setup (start?,stop?)>
+<!ATTLIST setup
+    name CDATA #IMPLIED
+  >
+
+<!ELEMENT start EMPTY>
+<!ATTLIST start
+    dir CDATA #IMPLIED
+    target CDATA #IMPLIED
+    antfile CDATA #IMPLIED
+    onBackground (true|false|yes|no|0|1) "false"
+    delay NMTOKEN "0"
+  >
+
+<!ELEMENT stop EMPTY>
+<!ATTLIST stop
+    dir CDATA #IMPLIED
+    target CDATA #IMPLIED
+    antfile CDATA #IMPLIED
+    onBackground (true|false|yes|no|0|1) "false"
+    delay NMTOKEN "0"
+  >
+

--- a/netbeans.apache.org/src/content/dtds/xtest-pes-config.dtd
+++ b/netbeans.apache.org/src/content/dtds/xtest-pes-config.dtd
@@ -1,0 +1,262 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!-- root element of PES configuration
+  
+  attributes:
+  
+    incomingDir: where PES expects results to be uploaded
+      this directory will have two subdirectories:
+        - replacement/
+          - results stored in this directory
+    	     will replace the already processed
+    		 results (if applicable)
+    	- invalid/
+    	  - here are placed results which cannot
+    		 be processes by PES (ivalid or incomplete
+    		 archive) - so they can be further 
+    		 investigated manually
+    		 
+    workDir: PES' working directory - used for processing
+       results before they are integrated to web
+       
+    loggingLevel: logging level of PES, which is used for writing out logs
+                  to standard output. Default value is WARNING
+                  usually there is no need to specify this attribute
+                  since 'WARNING' level is suitable for most users
+                  
+    databaseUploadPath: path, where resuls prepored for database upload. 
+                are stored. When this attribute is set, database upload 
+                mode is actiavated. More information on this topic will come soon.
+                
+    team:   default team of this PES instance. This attribute applies only
+            when databaseUploadPath is set, hence it is relevant only when
+            uploading results to database. Again more informatin on this 
+            will be written soon.
+	
+-->
+<!ELEMENT PESConfig (PESWeb, Mail?)>
+<!ATTLIST PESConfig
+	incomingDir         CDATA #REQUIRED
+	workDir             CDATA #REQUIRED
+        loggingLevel        (SEVERE|WARNING|INFO|FINE|FINER|FINEST) "WARNING"
+        databaseUploadPath  CDATA #IMPLIED
+        team                CDATA #IMPLIED
+>	
+
+
+<!-- element describing email settings for PES.
+  
+   This element is optional and when used, PES is able to send notification to 
+   it's administrators about exceptional states it encounters. Attributes are:
+   
+   smtpHost: host address which is running smtp daemon to send email. Unix workstation
+             are usually running this daemon. If you are not sure, please
+             ask your network administrator.
+         
+    from:    email account which is used as a sender of this message. 
+    to:      email account to which are all messages sent
+    loggingLevel: similarly as in the top element (PESConfig), but this logging 
+                level is used for sending notifications via email. Usually
+                there is no need to define this attribute, since 'SEVERE' level
+                is suitable for most users
+
+-->
+<!ELEMENT Mail EMPTY>
+<!ATTLIST Mail
+    smtpHost     CDATA #REQUIRED
+    from         CDATA #REQUIRED
+    to           CDATA #REQUIRED
+    loggingLevel (SEVERE|WARNING|INFO|FINE|FINER|FINEST) "SEVERE"
+>    
+
+<!-- element describing PES' web. Any PES instance can manage
+	  one or more websites, each is independent on each other
+	 - this functionality can be used to prepare archives
+	   for offline access or to prepare truncated results
+	   (results uploaded to netbeans.org)
+	 
+  attributes:
+
+    
+    webroot: directory in the filesystem which serve as
+    	web root for results (does not have to be 
+    	real webroot of the http server, but any
+    	subdirectory of it).
+    	
+    type: type of the web. Possible values are:
+      - main - main PES web - this is the only compulsory
+         web to be specified in the config. All other types
+         of web are created from this one. Only one main
+         web can exist in one PES instance.
+      - copy - full or partial copy of the main web. This
+         can be used when preparing subset of results to be
+         published on other network (e.g. netbeans.org)
+      - archive - web to be archived for offline access. It 
+          is actually full or partial copy of main web, but
+          results available in archive are deleted from main
+          web. If you need to keep them available on the
+          main web, use 'copy' value instead of 'archive'     
+    
+    truncate: setting this to true means, that results
+      in this web are truncated - i.e. no working
+      directories, IDE userdirs nor exception details
+      are available on this web
+      
+    includeExceptions: when set to true (default), exceptions thrown in the
+            tests are displayed with stack traces on the pages. If false, no
+            stacktraces are displayed.
+            
+    includeIDELogs: when set to true (default), ide logs are available from
+            the web pages.
+            
+    uploadToDatabase: if true (default), then results from this web will be uploaded
+        to database. This attribute depends on databaseUploadPath in PESConfig,
+        so if the databaseUploadPath is not set, then this attribute has no 
+        effect at all.            
+      
+    webURL: URL of the webroot. This attribute is required only when database
+            uploads are on (see databaseUploadPath attribute in PESConfig
+    
+-->     
+<!ELEMENT PESWeb (PESProjectGroup+)>
+<!ATTLIST PESWeb	
+	webroot  	  CDATA #REQUIRED
+	type		  (main|copy|archive) "main"
+	truncate	  (true|false) "false"
+        includeExceptions (true|false) "true"
+        includeIDELogs    (true|false) "true"
+        uploadToDatabase  (true|false) "true"
+        webURL          CDATA #IMPLIED
+>	
+
+
+
+
+<!-- this elements defines groups of projects
+	 available on the web. Each web can contain
+	 one or more projects group. Each project group
+	 can include one or more projects and is available
+	 on separate page. All group pages are connected 
+	 together via links.
+	 
+  attributes:
+  	
+  	name: name of the group - this name is displayed
+  	  in the title of the main group page as well on 
+  	  links pointing to this page
+  	  
+  	description: detailed description of this group -
+  		description is displayed on the group summary page
+  		
+  	main: if true, this group is taken as the main group
+  		on the web site (is available in index.html).
+                It also means that all results which does
+                not fit into any other group will stay in this
+                group (even though there are not defined)
+  		  		
+  	historyMatrices: if true, historyMatrices are
+  	  created for this group, if false, no history matrices
+  	  are produced
+  	  
+  	currentBuilds: defines number of builds which are
+  	  considered as current - they are available
+  	  on the first projects summary page. Any build
+  	  'older' than the number specified is available
+  	  in other page. If not defined - no older builds
+          are created
+  	
+  	detailedData: defines number of builds for which are
+  	  detailed data kept available. When a build is older then
+  	  defined number, all detailed data (workdirs, logs, IDE userdirs)
+  	  are deleted. When not defined, no detailed data are deleted.
+          
+        uploadToDatabase: this settings applied only when databaseUploadPath
+            is set in PESConfig element. Basically this let you to let the results 
+            from this group to be uploaded to database, or disables (when set to
+            false) the upload of all results from this group
+              
+	 
+ -->
+<!ELEMENT PESProjectGroup (PESProject*)>
+<!ATTLIST PESProjectGroup
+	name 			CDATA 		#REQUIRED
+	description 		CDATA 		#REQUIRED
+	main 			(true|false)	"false"	
+	historyMatrices 	CDATA   	#IMPLIED
+	currentBuilds 		CDATA 		#IMPLIED
+	detailedData		CDATA 		#IMPLIED
+        uploadToDatabase        (true|false)    "true"
+>
+
+
+
+
+<!-- PESProject defines logical project which is managed
+ 	 in this group.
+ 	 
+  attributes:
+         
+    project: real name of the project as is defined
+      in the submitted results. This attribute serves
+      as 'link' to the tested project (i.e. even
+      though on pages is displayed logical names, 
+      the shown data are from this project. Attribute
+      can contain regular expression (with syntax 
+      conforming to JDK 1.4 regex package)
+      
+    department: from which department should
+      be tests included in this project. Usually one real 
+      project can be tested by several groups  (like
+      QA, Development, RE) and results needs to be
+      kept separately. If not defined, all departments
+      are included.  Attribute can also contain
+      regular expression (with syntax conforming to
+      JDK 1.4 regex package)
+      
+    testType: which test type should be included in this
+      project. Similarly as with department - one real
+      project can be tested with several test types (e.g.
+      functional, performance, unit ...). If this attribute
+      is not defined, then all test types are included. 
+      Likewise with project and department, testType can 
+      contain regular expression.
+      
+     fromBuild: from which build should be project
+       available in this logical project. If not defined,
+       all builds from beginning to buildTo are included
+       in this logical project.
+     
+     toBuild: to which build should be project available
+       in this logical project. If not defined, all
+       builds from buildFrom are included in this
+       logical project.
+      
+-->	 
+<!ELEMENT PESProject EMPTY>
+<!ATTLIST PESProject
+	project		CDATA	#REQUIRED	
+	department	CDATA 	#IMPLIED
+	testType	CDATA	#IMPLIED
+	fromBuild	CDATA	#IMPLIED
+	toBuild 	CDATA	#IMPLIED
+>	
+	
+	

--- a/netbeans.apache.org/src/content/dtds/xtest-plugin-descriptor.dtd
+++ b/netbeans.apache.org/src/content/dtds/xtest-plugin-descriptor.dtd
@@ -1,0 +1,148 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!--
+    Document   : plugin_descriptor.dtd
+    Created on : February 17, 2004, 4:53 PM
+    Author     : Martin Brehovsky
+    Description:
+       This DTD describes XTest's Plugin descriptor. 
+       Comments above each definition describe the element/attribute purpose
+-->
+
+
+<!-- this is the topmost element -->
+<!ELEMENT XTestPlugin (Dependencies, AvailableCompilers?, AvailablePackagers?,
+                       AvailableExecutors?, AvailableResultProcessors?)>
+<!-- attributes for XTestPlugin element
+    - name      - the name of the plugin, it also servers as a plugin ID
+    - version   - version of the plugin
+    - extends   - in the case the plugin extends already existing plugin, this 
+                  attribute should containt the name (ID) of the extended plugin
+-->
+<!ATTLIST XTestPlugin
+    name     CDATA #REQUIRED
+    version  CDATA #REQUIRED
+    extends  CDATA #IMPLIED
+>
+
+<!-- Dependencies element defines dependecies of this plugin on XTest and other plugins
+     Please note this element is required
+-->
+<!ELEMENT Dependencies (UsePlugin)>
+
+<!-- attributes for Dependecies element
+    - requiredXTestVersion - the lowest version of XTest capable running this
+                             plugin. 
+-->
+<!ATTLIST Dependencies
+    requiredXTestVersion CDATA #REQUIRED
+>
+
+<!-- element used to define dependecies on other plugins
+         - when dependency is defined, XTest then in runtime exports information
+              about the plugin described here, such as home dir, so the declaring
+              plugin can access its resources -->
+<!ELEMENT UsePlugin EMPTY>
+<!-- attributes for UsePlugin element
+    - name    - name of the plugin to be depended on
+    - version - the lowest version of the plugin, so it is compatible with this
+                plugin
+-->                
+<!ATTLIST UsePlugin
+    name    CDATA #REQUIRED
+    version CDATA #REQUIRED
+>
+
+<!-- this element contains all compilers supplied by the plugin -->
+<!ELEMENT AvailableCompilers (Compiler+)>
+
+<!-- this element describes a particular compiler supplied by the plugin -->
+<!ELEMENT Compiler EMPTY>
+<!-- attributes for Compiler element
+    - id      - name or ide of the supplied compiler - this name is used by test 
+                scripts when calling a particular (non default) compiler
+    - antfile - file with relative path to this descriptor which contains the 
+                compiler ant target
+    - target  - target in the {antfile} executed as the compiler
+    - dafault - whether this compiler is default (i.e. called when no compiler
+                is specified)
+-->                
+<!ATTLIST Compiler
+   id      CDATA #REQUIRED
+   antfile CDATA #REQUIRED
+   target  CDATA #REQUIRED
+   default (true|false) "false"
+>
+
+<!-- this element contains all packagers supplied by the plugin -->
+<!ELEMENT AvailablePackagers (Packager+)>
+
+<!-- this element describes a particular packager supplied by the plugin -->
+<!ELEMENT Packager EMPTY>
+<!-- attributes for Packager element
+     - attributes meaning is exactly the same as for the Compiler element
+-->   
+<!ATTLIST Packager
+   id      CDATA #REQUIRED
+   antfile CDATA #REQUIRED
+   target  CDATA #REQUIRED
+   default (true|false) "false"
+>
+
+<!-- this element contains all executors supplied by the plugin -->
+<!ELEMENT AvailableExecutors (Executor+)>
+
+<!-- this element describes a particular executor supplied by the plugin -->
+<!ELEMENT Executor EMPTY>
+<!-- attributes for Executor element
+     - attributes meaning is exactly the same as for the Compiler element
+-->   
+<!ATTLIST Executor
+   id      CDATA #REQUIRED
+   antfile CDATA #REQUIRED
+   target  CDATA #REQUIRED
+   default (true|false) "false"
+>
+
+<!-- this element contains all result processors supplied by the plugin -->
+<!ELEMENT AvailableResultProcessor (ResultProcessor+)>
+
+<!-- this element describes a particular result processor supplied by the plugin -->
+<!ELEMENT ResultProcessor EMPTY>
+<!-- attributes for ResultProcessor element
+     - executorID - id of the executor, after which execution should be this 
+                    result processor used to process the gathered results
+     - the rest of attributes meaning is exactly the same as for the Compiler element
+-->   
+<!ATTLIST ResultProcessor
+   id         CDATA #REQUIRED
+   executorID CDATA #IMPLIED
+   antfile    CDATA #REQUIRED
+   target     CDATA #REQUIRED
+   default   (true|false) "false"
+>
+
+
+
+
+
+
+


### PR DESCRIPTION
All DTDs should contain the APLv2 license.