### PR TITLE
contrast fix for main cards

### DIFF
--- a/netbeans.apache.org/src/content/scss/components/_card.scss
+++ b/netbeans.apache.org/src/content/scss/components/_card.scss
@@ -35,9 +35,9 @@
     padding: 1em;
 
     a {
-            color: #fff;
-            text-decoration: underline;
-            font-weight: bold;
+        color: #fff;
+        text-decoration: underline;
+        font-weight: bold;
     }
 
     .title {
@@ -48,14 +48,18 @@
 }
 
 .paragraph.card.blue {
-        background-color: $nb-blue;
+	background-color: $nb-blue;
 }
 
 .paragraph.card.green {
-        background-color: $nb-green;
+    background-color: $nb-green;
+    color: #000; // contrast
+    a {
+        color: #000;
+    }
 }
 
 .paragraph.card.magenta {
-        background-color: $nb-magenta;
+    background-color: $nb-magenta;
 }
 


### PR DESCRIPTION
There is a very low contrast on the main page on the green card (below 2). The other cards is about 5 and 8 so acceptable. A simple fix is to change color of the text to black as in the patch. 

Another option is to use darker green. But would need to be at least `#809D2A` to to be viable for large text and `#667D21` for small text.