### PR TITLE
footer  fix date + link to main download page

### DIFF
--- a/netbeans.apache.org/src/content/templates/footer.gsp
+++ b/netbeans.apache.org/src/content/templates/footer.gsp
@@ -80,7 +80,7 @@
                 </ul>
             </div>
             <div class="large-auto cell">
-                <h1><a href="/download/nb110/nb110.html">Download</a></h1>
+                <h1><a href="/download/index.html">Download</a></h1>
                 <ul>
                     <li><a href="/download/index.html">Releases</a></li>                    
                     <li><a href="https://plugins.netbeans.apache.org/">Plugins</a></li>
@@ -93,7 +93,7 @@
 </footer>
 <div class='footer-disclaimer'>
     <div class="footer-disclaimer-content">
-        <p>Copyright &copy; 2017-2020 <a href="https://www.apache.org">The Apache Software Foundation</a>.</p>
+        <p>Copyright &copy; 2017-2022 <a href="https://www.apache.org">The Apache Software Foundation</a>.</p>
         <p>Licensed under the Apache <a href="https://www.apache.org/licenses/">license</a>, version 2.0</p>
         <div style='max-width: 40em; margin: 0 auto'>
             <p>Apache, Apache NetBeans, NetBeans, the Apache feather logo and the Apache NetBeans logo are trademarks of <a href="https://www.apache.org">The Apache Software Foundation</a>.</p>


### PR DESCRIPTION
change copyright date range to 2022
main download in footer leads to version 11.0