### PR TITLE
Update Oracle-transition doc to refer to https

### DIFF
--- a/netbeans.apache.org/src/content/about/oracle-transition.asciidoc
+++ b/netbeans.apache.org/src/content/about/oracle-transition.asciidoc
@@ -44,7 +44,7 @@ In case you still need to access Oracle binaries or artifacts, some individuals 
 
 === Maven repository
 
-Jaroslav Tulach is hosting a Maven repository with all previous Oracle binaries at http://netbeans.apidesign.org/maven2/. You can use this repository by adding the following to your `pom.xml`:
+Jaroslav Tulach is hosting a Maven repository with all previous Oracle binaries at https://netbeans.apidesign.org/maven2/. You can use this repository by adding the following to your `pom.xml`:
 
 [code, xml]
 ----
@@ -53,7 +53,7 @@ Jaroslav Tulach is hosting a Maven repository with all previous Oracle binaries 
         <repository>
             <id>netbeans</id>
             <name>NetBeans</name>
-            <url>http://netbeans.apidesign.org/maven2/</url>
+            <url>https://netbeans.apidesign.org/maven2/</url>
         </repository>
     </repositories>
 <build> 


### PR DESCRIPTION
Maven now enforces use of https. So would be wrong to instruct users to have a Maven Repo reference in their POM which uses http. (the `netbeans.apidesign.org/maven2` site supports both http and https)

Note: In case you wonder. I haven't changed the `http://source.apidesign.org/hg/netbeans/` URL because
1. it is not relevant to the problem at hand
2. target website starts asking for authentication when you switch from http to https. Don't know why.