### PR TITLE
Update .htaccess for NetBeans 17

### DIFF
--- a/netbeans.apache.org/src/content/.htaccess
+++ b/netbeans.apache.org/src/content/.htaccess
@@ -33,6 +33,8 @@ Redirect 302 /nb/updates/15/ https://netbeans-vm1.apache.org/uc/15/
 Redirect 302 /nb/plugins/15/ https://plugins.netbeans.apache.org/data/15/
 Redirect 302 /nb/updates/16/ https://netbeans-vm1.apache.org/uc/16/
 Redirect 302 /nb/plugins/16/ https://plugins.netbeans.apache.org/data/16/
+Redirect 302 /nb/updates/17/ https://netbeans-vm1.apache.org/uc/17/
+Redirect 302 /nb/plugins/17/ https://plugins.netbeans.apache.org/data/16/
 Redirect 302 /nb/updates/dev/ https://netbeans-vm1.apache.org/uc/dev/
 Redirect 302 /nb/plugins/dev/ https://plugins.netbeans.apache.org/data/16/
 Redirect 302 /nb/issues_redirect.html https://netbeans.apache.org/participate/report-issue.html


### PR DESCRIPTION
Update .htaccess for NetBeans 17, including temporary redirect for plugins to NB16 portal.

cc @jkovalsky for info